### PR TITLE
Fix serialization issue in SklearnSerializer by ensuring correct attribute type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ pip install openmodels
 
 ```python
 from openmodels import SerializationManager, SklearnSerializer
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.decomposition import PCA
 from sklearn.datasets import make_classification
 
 # Create and train a scikit-learn model
-X, y = make_classification(n_samples=1000, n_features=4, n_informative=2, n_redundant=0, random_state=0, shuffle=False)
-model = RandomForestClassifier(n_estimators=10, max_depth=5, random_state=0)
-model.fit(X, y)
+X, _ = make_classification(n_samples=1000, n_features=4, n_informative=2, n_redundant=0, random_state=0, shuffle=False)
+model = PCA(n_components=2, random_state=0)
+model.fit(X)
 
 # Create a SerializationManager
 manager = SerializationManager(SklearnSerializer())
@@ -41,8 +41,8 @@ serialized_model = manager.serialize(model)
 deserialized_model = manager.deserialize(serialized_model)
 
 # Use the deserialized model
-predictions = deserialized_model.predict(X[:5])
-print(predictions)
+transformed_data = deserialized_model.transform(X[:5])
+print(transformed_data)
 ```
 
 ## Extensibility

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -122,18 +122,6 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, list] = {
     ],
 }
 
-# List of supported types for serialization
-SUPPORTED_TYPES: List[Type] = [
-    bool,
-    str,
-    int,
-    float,
-    list,
-    tuple,
-    np.float64,
-    np.ndarray,
-]
-
 
 class SklearnSerializer(ModelSerializer):
     """
@@ -222,8 +210,12 @@ class SklearnSerializer(ModelSerializer):
                 return int(value)
             elif attr_type == "float":
                 return float(value)
+            elif attr_type == "float64":
+                return np.float64(value)
             elif attr_type == "str":
                 return str(value)
+            elif attr_type == "tuple":
+                return tuple(value)
             # Add other types as needed
             return value  # Return as-is if no specific conversion is needed
         # Recursive case: if attr_type is a list, process each element in value

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -282,11 +282,11 @@ class SklearnSerializer(ModelSerializer):
     @staticmethod
     def get_dtype(value: Any) -> str:
         """
-        Get the dtype of a numpy array, otherwise return None.
+        Get the dtype of a numpy array, otherwise return empty string.
         """
         if isinstance(value, np.ndarray):
             return str(value.dtype)  # Get the actual numpy dtype
-        return None
+        return ''
 
 
     def serialize(self, model: BaseEstimator) -> Dict[str, Any]:

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -282,13 +282,11 @@ class SklearnSerializer(ModelSerializer):
     @staticmethod
     def get_dtype(value: Any) -> str:
         """
-        Get the dtype of a numpy array or scalar, otherwise return the type name.
+        Get the dtype of a numpy array, otherwise return None.
         """
         if isinstance(value, np.ndarray):
             return str(value.dtype)  # Get the actual numpy dtype
-        elif isinstance(value, (int, float, np.integer, np.floating)):
-            return type(value).__name__  # Get the type of scalar values
-        return type(value).__name__  # For other objects, return class name
+        return None
 
 
     def serialize(self, model: BaseEstimator) -> Dict[str, Any]:

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -367,6 +367,12 @@ class SklearnSerializer(ModelSerializer):
             self._convert_to_serializable_types(value) for value in attribute_values
         ]
 
+        attribute_dtypes = {
+            key: SklearnSerializer.get_dtype(value) 
+            for key, value in zip(filtered_attribute_keys, attribute_values)
+            if isinstance(value, np.ndarray)  # Only include NumPy arrays
+        }
+
         # We losely follow the ONNX standard for the serialized model.
         # https://github.com/onnx/onnx/blob/main/docs/IR.md
         return {
@@ -374,7 +380,7 @@ class SklearnSerializer(ModelSerializer):
                 zip(filtered_attribute_keys, serializable_attribute_values)
             ),
             "attribute_types": dict(zip(filtered_attribute_keys, attribute_types)),
-            "attribute_dtypes": dict(zip(filtered_attribute_keys, attribute_dtypes)),
+            "attribute_dtypes": attribute_dtypes,
             "estimator_class": model.__class__.__name__,
             "params": model.get_params(),
             "producer_name": model.__module__.split(".")[0],

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -358,10 +358,6 @@ class SklearnSerializer(ModelSerializer):
             SklearnSerializer.get_nested_types(value) for value in attribute_values
         ]
 
-        attribute_dtypes = [
-            SklearnSerializer.get_dtype(value) for value in attribute_values
-        ]
-
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values
         ]

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -176,7 +176,9 @@ class SklearnSerializer(ModelSerializer):
         return value
 
     @staticmethod
-    def _convert_to_sklearn_types(value: Any, attr_type: Any = "none", attr_dtype: Optional[str] = None) -> Any:
+    def _convert_to_sklearn_types(
+        value: Any, attr_type: Any = "none", attr_dtype: Optional[str] = None
+    ) -> Any:
         """
         Convert a JSON-deserialized value to its scikit-learn type.
 
@@ -277,8 +279,7 @@ class SklearnSerializer(ModelSerializer):
         else:
             # Return the type name if it's not a list or it's an empty list
             return type(item).__name__
-        
-    
+
     @staticmethod
     def get_dtype(value: Any) -> str:
         """
@@ -286,8 +287,7 @@ class SklearnSerializer(ModelSerializer):
         """
         if isinstance(value, np.ndarray):
             return str(value.dtype)  # Get the actual numpy dtype
-        return ''
-
+        return ""
 
     def serialize(self, model: BaseEstimator) -> Dict[str, Any]:
         """
@@ -362,13 +362,12 @@ class SklearnSerializer(ModelSerializer):
             SklearnSerializer.get_dtype(value) for value in attribute_values
         ]
 
-
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values
         ]
 
         attribute_dtypes_map = {
-            key: SklearnSerializer.get_dtype(value) 
+            key: SklearnSerializer.get_dtype(value)
             for key, value in zip(filtered_attribute_keys, attribute_values)
             if isinstance(value, np.ndarray)  # Only include NumPy arrays
         }
@@ -429,8 +428,12 @@ class SklearnSerializer(ModelSerializer):
             # Retrieve the attribute type from data["attribute_types"]
             attr_type = data["attribute_types"].get(attribute)
             # Get dtype if available
-            attr_dtype = data.get("attribute_dtypes", {}).get(attribute)  
+            attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
             # Pass both value and attr_type to _convert_to_sklearn_types
-            setattr(model, attribute, self._convert_to_sklearn_types(value, attr_type, attr_dtype))
+            setattr(
+                model,
+                attribute,
+                self._convert_to_sklearn_types(value, attr_type, attr_dtype),
+            )
 
         return model

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -5,7 +5,7 @@ This module provides a serializer for scikit-learn models, allowing them to be
 converted to and from dictionary representations.
 """
 
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
@@ -176,7 +176,7 @@ class SklearnSerializer(ModelSerializer):
         return value
 
     @staticmethod
-    def _convert_to_sklearn_types(value: Any, attr_type: Any = "none", attr_dtype: str = None) -> Any:
+    def _convert_to_sklearn_types(value: Any, attr_type: Any = "none", attr_dtype: Optional[str] = None) -> Any:
         """
         Convert a JSON-deserialized value to its scikit-learn type.
 
@@ -367,7 +367,7 @@ class SklearnSerializer(ModelSerializer):
             self._convert_to_serializable_types(value) for value in attribute_values
         ]
 
-        attribute_dtypes = {
+        attribute_dtypes_map = {
             key: SklearnSerializer.get_dtype(value) 
             for key, value in zip(filtered_attribute_keys, attribute_values)
             if isinstance(value, np.ndarray)  # Only include NumPy arrays
@@ -380,7 +380,7 @@ class SklearnSerializer(ModelSerializer):
                 zip(filtered_attribute_keys, serializable_attribute_values)
             ),
             "attribute_types": dict(zip(filtered_attribute_keys, attribute_types)),
-            "attribute_dtypes": attribute_dtypes,
+            "attribute_dtypes": attribute_dtypes_map,
             "estimator_class": model.__class__.__name__,
             "params": model.get_params(),
             "producer_name": model.__module__.split(".")[0],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openmodels"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 description = "Export scikit-learn model files to JSON for sharing or deploying predictive models with peace of mind."
 authors = [
     "Alejandro Gutierrez <agutierrez@sftec.es>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>, Ruben Parrilla <rparrilla@sftec.es>",

--- a/test/test_classification.py
+++ b/test/test_classification.py
@@ -107,7 +107,6 @@ def test_qda(data):
     )
 
 
-@pytest.mark.skip(reason="Feature not ready")
 def test_svm(data):
     x, y, x_sparse, y_sparse = data
     # Ensure sparse data is properly formatted before testing

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -55,7 +55,6 @@ def test_ridge_regression(data):
     run_test_model(Ridge(alpha=0.5), x, y, x_sparse, y_sparse, "ridge-regression.json")
 
 
-@pytest.mark.skip(reason="Feature not ready")
 def test_svr(data):
     x, y, x_sparse, y_sparse = data
     # Ensure sparse data is properly formatted before testing


### PR DESCRIPTION
Resolved incorrect type conversion in _convert_to_sklearn_types, ensuring proper handling of attribute types and dtypes.