### PR TITLE
refactor: dynamic estimator loading in sklearn serializer

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 99
+max-line-length = 200
 extend-ignore = E203, W503
 max-complexity = 10

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ OpenModels currently supports a wide range of scikit-learn models, including:
 - Clustering: KMeans
 - Dimensionality Reduction: PCA
 
-For a full list of supported models, please refer to the `SUPPORTED_ESTIMATORS` dictionary in `serializers/sklearn_serializer.py`.
+For a full list of supported models, please refer to the `SUPPORTED_ESTIMATORS` list in `serializers/sklearn_serializer.py`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,34 @@ class TensorFlowSerializer(ModelSerializer):
         ...
 ```
 
-## Supported Models
+## Supported Models (scikit-learn)
 
 OpenModels currently supports a wide range of scikit-learn models, including:
 
-- Classification: LogisticRegression, RandomForestClassifier, SVC, etc.
-- Regression: LinearRegression, RandomForestRegressor, SVR, etc.
+- Classification: LogisticRegression, SVC, etc.
+- Regression: LinearRegression, SVR, etc.
 - Clustering: KMeans
 - Dimensionality Reduction: PCA
 
-For a full list of supported models, please refer to the `SUPPORTED_ESTIMATORS` list in `serializers/sklearn_serializer.py`.
+For a full list of supported models, you can programmatically retrieve them using the `SklearnSerializer.all_estimators()` method:
+
+```python
+from openmodels.serializers import SklearnSerializer
+
+# Get all supported estimators (classifiers, regressors, etc.)
+all_supported = SklearnSerializer.all_estimators()
+print([name for name, cls in all_supported])
+
+# To get only classifiers:
+classifiers = SklearnSerializer.all_estimators(type_filter="classifier")
+print([name for name, cls in classifiers])
+
+# To get only regressors:
+regressors = SklearnSerializer.all_estimators(type_filter="regressor")
+print([name for name, cls in regressors])
+```
+
+This will print the names of all scikit-learn estimators supported by OpenModels, filtered to exclude those that are not currently supported.
 
 ## Contributing
 

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,6 +33,7 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
+        print(f"Serializing data to JSON: {data}")
         return json.dumps(data)
 
     @staticmethod

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,7 +33,6 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
-        print(f"Serializing data to JSON: {data}")
         return json.dumps(data)
 
     @staticmethod

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -477,10 +477,6 @@ class SklearnSerializer(ModelSerializer):
         }
 
         attribute_types_map = dict(zip(filtered_attribute_keys, attribute_types))
-        # Print debug information
-        # print("--------", model.__class__.__name__, "--------")
-        # print(attribute_types_map)
-        # print(attribute_dtypes_map)
 
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -63,7 +63,7 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "PassiveAggressiveClassifier",  # Object of type Hinge is not JSON serializable
     "Perceptron",  # Object of type Hinge is not JSON serializable
     "RadiusNeighborsClassifier",  # Object of type KDTree is not JSON serializable
-    "RandomForestClassifier",  #  Object of type DecisionTreeClassifier is not JSON serializable
+    "RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "RidgeClassifier",  # Object of type LabelBinarizer is not JSON serializable
     "RidgeClassifierCV",  # Object of type LabelBinarizer is not JSON serializable
     "SGDClassifier",  # Object of type Hinge is not JSON serializable

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -22,113 +22,113 @@ ALL_ESTIMATORS = {
 
 NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
-    "AdaBoostRegressor", #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "BaggingRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreesRegressor", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "GammaRegressor", # TypeError: Object of type HalfGammaLoss is not JSON serializable
-    "GaussianProcessRegressor", # TypeError: Object of type Product is not JSON serializable
-    "GradientBoostingRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingRegressor", # TypeError: Object of type HalfSquaredError is not JSON serializable
-    "IsotonicRegression", # TypeError: Object of type interp1d is not JSON serializable
-    "MultiOutputRegressor", # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
-    "PoissonRegressor", # TypeError: Object of type HalfPoissonLoss is not JSON serializable
-    "RandomForestRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "RANSACRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
-    "RegressorChain", # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "StackingRegressor", # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
-    "TransformedTargetRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
-    "DecisionTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
-    "TweedieRegressor", # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
-    "VotingRegressor", # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "AdaBoostRegressor",  #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "BaggingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "DecisionTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreesRegressor",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "GammaRegressor",  # TypeError: Object of type HalfGammaLoss is not JSON serializable
+    "GaussianProcessRegressor",  # TypeError: Object of type Product is not JSON serializable
+    "GradientBoostingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingRegressor",  # TypeError: Object of type HalfSquaredError is not JSON serializable
+    "IsotonicRegression",  # TypeError: Object of type interp1d is not JSON serializable
+    "MultiOutputRegressor",  # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
+    "PoissonRegressor",  # TypeError: Object of type HalfPoissonLoss is not JSON serializable
+    "RandomForestRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "RANSACRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
+    "RegressorChain",  # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "StackingRegressor",  # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "TransformedTargetRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
+    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
+    "TweedieRegressor",  # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
+    "VotingRegressor",  # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
-    "AdaBoostClassifier", # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "BaggingClassifier", # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "CalibratedClassifierCV", # TypeError: Object of type _CalibratedClassifier is not JSON serializable
-    "ClassifierChain", # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "DecisionTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreesClassifier", # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
-    "FixedThresholdClassifier", # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "GaussianProcessClassifier", # TypeError: Object of type OneVsRestClassifier is not JSON serializable
-    "GradientBoostingClassifier", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingClassifier", # TypeError: Object of type TreePredictor is not JSON serializable
-    "KNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
-    "MLPClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "MultiOutputClassifier", # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsOneClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsRestClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OutputCodeClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "PassiveAggressiveClassifier", # TypeError: Object of type Hinge is not JSON serializable
-    "Perceptron", # TypeError: Object of type Hinge is not JSON serializable
-    "RadiusNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
-    "RandomForestClassifier", #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "SGDClassifier", # TypeError: Object of type Hinge is not JSON serializable
-    "SelfTrainingClassifier", # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
-    "StackingClassifier", # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
-    "TunedThresholdClassifierCV", # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
-    "VotingClassifier", # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "AdaBoostClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "BaggingClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "CalibratedClassifierCV",  # TypeError: Object of type _CalibratedClassifier is not JSON serializable
+    "ClassifierChain",  # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
+    "ExtraTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
+    "ExtraTreesClassifier",  # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
+    "FixedThresholdClassifier",  # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "GaussianProcessClassifier",  # TypeError: Object of type OneVsRestClassifier is not JSON serializable
+    "GradientBoostingClassifier",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingClassifier",  # TypeError: Object of type TreePredictor is not JSON serializable
+    "KNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
+    "MLPClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "MultiOutputClassifier",  # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsOneClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsRestClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OutputCodeClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "PassiveAggressiveClassifier",  # TypeError: Object of type Hinge is not JSON serializable
+    "Perceptron",  # TypeError: Object of type Hinge is not JSON serializable
+    "RadiusNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
+    "RandomForestClassifier",  #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "RidgeClassifierCV",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "SGDClassifier",  # TypeError: Object of type Hinge is not JSON serializable
+    "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
+    "StackingClassifier",  # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "TunedThresholdClassifierCV",  # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
+    "VotingClassifier",  # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
     # Clusters:
-    "Birch", # TypeError: Object of type _CFNode is not JSON serializable
-    "BisectingKMeans", # TypeError: Object of type _BisectingTree is not JSON serializable
-    "FeatureAgglomeration", # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
-    "HDBSCAN", # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
+    "Birch",  # TypeError: Object of type _CFNode is not JSON serializable
+    "BisectingKMeans",  # TypeError: Object of type _BisectingTree is not JSON serializable
+    "FeatureAgglomeration",  # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
+    "HDBSCAN",  # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
     # Transformers:
-    "ColumnTransformer", # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
-    "DictVectorizer", # TypeError: Object of type type is not JSON serializable (in params)
-    "FeatureHasher", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "FeatureUnion", # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
-    "GaussianRandomProjection", # TypeError: Object of type RandomState is not JSON serializable
-    "GenericUnivariateSelect", # TypeError: Object of type function is not JSON serializable
-    "HashingVectorizer", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap", # TypeError: Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer", # TypeError: Object of type OneHotEncoder is not JSON serializable
-    "KNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
-    "KernelPCA", # TypeError: Object of type KernelCenterer is not JSON serializable
-    "LatentDirichletAllocation", # TypeError: Object of type RandomState is not JSON serializable
-    "LinearDiscriminantAnalysis", # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
-    "LocallyLinearEmbedding", # TypeError: Object of type NearestNeighbors is not JSON serializable"
-    "LabelBinarizer", # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "LabelEncoder", # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
-    "MultiLabelBinarizer", # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "NeighborhoodComponentsAnalysis", # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
-    "OneHotEncoder", # TypeError: Object of type type is not JSON serializable
-    "OrdinalEncoder", # TypeError: Object of type type is not JSON serializable
-    "PatchExtractor", # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer", # TypeError: Object of type StandardScaler is not JSON serializable
-    "RFE", # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
-    "RFECV", # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
-    "RadiusNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "SelectFdr", # TypeError: Object of type function is not JSON serializable
-    "SelectFpr", # TypeError: Object of type function is not JSON serializable
-    "SelectFromModel", # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
-    "SelectFwe", # TypeError: Object of type function is not JSON serializable
-    "SelectKBest", # TypeError: Object of type function is not JSON serializable
-    "SelectPercentile", # TypeError: Object of type function is not JSON serializable
-    "SequentialFeatureSelector", # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
-    "SimpleImputer", # TypeError: Object of type Float64DType is not JSON serializable
-    "SkewedChi2Sampler", # ValueError: X may not contain entries smaller than -skewedness.
-    "SparseCoder", # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
-    "SparseRandomProjection", # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
-    "SplineTransformer", # TypeError: Object of type BSpline is not JSON serializable
-    "TargetEncoder", # ValueError: Expected array-like (array or non-string sequence), got None
-    "TfidfTransformer", # ValueError
+    "ColumnTransformer",  # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
+    "DictVectorizer",  # TypeError: Object of type type is not JSON serializable (in params)
+    "FeatureHasher",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "FeatureUnion",  # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
+    "GaussianRandomProjection",  # TypeError: Object of type RandomState is not JSON serializable
+    "GenericUnivariateSelect",  # TypeError: Object of type function is not JSON serializable
+    "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "Isomap",  # TypeError: Object of type KernelPCA is not JSON serializable
+    "KBinsDiscretizer",  # TypeError: Object of type OneHotEncoder is not JSON serializable
+    "KNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
+    "KernelPCA",  # TypeError: Object of type KernelCenterer is not JSON serializable
+    "LatentDirichletAllocation",  # TypeError: Object of type RandomState is not JSON serializable
+    "LinearDiscriminantAnalysis",  # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
+    "LocallyLinearEmbedding",  # TypeError: Object of type NearestNeighbors is not JSON serializable"
+    "LabelBinarizer",  # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "LabelEncoder",  # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
+    "MultiLabelBinarizer",  # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "NeighborhoodComponentsAnalysis",  # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
+    "OneHotEncoder",  # TypeError: Object of type type is not JSON serializable
+    "OrdinalEncoder",  # TypeError: Object of type type is not JSON serializable
+    "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
+    "PowerTransformer",  # TypeError: Object of type StandardScaler is not JSON serializable
+    "RFE",  # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
+    "RFECV",  # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
+    "RadiusNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
+    "RandomTreesEmbedding",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "SelectFdr",  # TypeError: Object of type function is not JSON serializable
+    "SelectFpr",  # TypeError: Object of type function is not JSON serializable
+    "SelectFromModel",  # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
+    "SelectFwe",  # TypeError: Object of type function is not JSON serializable
+    "SelectKBest",  # TypeError: Object of type function is not JSON serializable
+    "SelectPercentile",  # TypeError: Object of type function is not JSON serializable
+    "SequentialFeatureSelector",  # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
+    "SimpleImputer",  # TypeError: Object of type Float64DType is not JSON serializable
+    "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
+    "SparseCoder",  # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
+    "SparseRandomProjection",  # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
+    "SplineTransformer",  # TypeError: Object of type BSpline is not JSON serializable
+    "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
+    "TfidfTransformer",  # ValueError
     # Others:
-    "BayesianGaussianMixture", # TypeError: Object of type ndarray is not JSON serializable
-    "CountVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    "FrozenEstimator", # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
-    "GridSearchCV", # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "KernelDensity", # TypeError: Object of type KDTree is not JSON serializable
-    "LocalOutlierFactor", # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
-    "Pipeline", # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
-    "RandomizedSearchCV", # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
-    "SGDOneClassSVM", # TypeError: Object of type Hinge is not JSON serializable
-    "TfidfVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+    "BayesianGaussianMixture",  # TypeError: Object of type ndarray is not JSON serializable
+    "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+    "FrozenEstimator",  # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
+    "GridSearchCV",  # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
+    "IsolationForest",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "KernelDensity",  # TypeError: Object of type KDTree is not JSON serializable
+    "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
+    "Pipeline",  # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
+    "RandomizedSearchCV",  # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
+    "SGDOneClassSVM",  # TypeError: Object of type Hinge is not JSON serializable
+    "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
 ]
 
 # Dictionary of attribute exceptions

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -75,7 +75,7 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "Birch",  # Object of type _CFNode is not JSON serializable
     "BisectingKMeans",  # Object of type _BisectingTree is not JSON serializable
     "FeatureAgglomeration",  # Object of type _ArrayFunctionDispatcher is not JSON serializable
-    "HDBSCAN",  # data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
+    "HDBSCAN",  # data type "[('left_node', '<i8'), ('right_node', '<i8')...]" not understood
     # Transformers:
     "ColumnTransformer",  # ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
     "DictVectorizer",  # Object of type type is not JSON serializable (in params)
@@ -89,12 +89,12 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "KNeighborsTransformer",  # Object of type KDTree is not JSON serializable
     "KernelPCA",  # Object of type KernelCenterer is not JSON serializable
     "LatentDirichletAllocation",  # Object of type RandomState is not JSON serializable
-    "LinearDiscriminantAnalysis",  # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
+    "LinearDiscriminantAnalysis",  # This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
     "LocallyLinearEmbedding",  # Object of type NearestNeighbors is not JSON serializable"
     "LabelBinarizer",  # LabelBinarizer.fit() takes 2 positional arguments but 3 were given
     "LabelEncoder",  # LabelEncoder.fit() takes 2 positional arguments but 3 were given
     "MultiLabelBinarizer",  # MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "NeighborhoodComponentsAnalysis",  # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
+    "NeighborhoodComponentsAnalysis",  # This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
     "OneHotEncoder",  # Object of type type is not JSON serializable
     "OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
@@ -113,7 +113,7 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "SimpleImputer",  # Object of type Float64DType is not JSON serializable
     "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
     "SparseCoder",  # SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
-    "SparseRandomProjection",  # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
+    "SparseRandomProjection",  # ValueError: lead to a target dimension of 3353 which is larger than the original space with n_features=5
     "SplineTransformer",  # Object of type BSpline is not JSON serializable
     "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
     "TfidfTransformer",  # ValueError

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -5,13 +5,13 @@ This module provides a serializer for scikit-learn models, allowing them to be
 converted to and from dictionary representations.
 """
 
-from typing import Any, Dict, Type, Optional
+from typing import Any, Dict, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
-from sklearn.utils import all_estimators
+from sklearn.utils.discovery import all_estimators
 
 from openmodels.exceptions import UnsupportedEstimatorError, SerializationError
 from openmodels.protocols import ModelSerializer

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -22,113 +22,113 @@ ALL_ESTIMATORS = {
 
 NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
-    "AdaBoostRegressor",  #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "BaggingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreesRegressor",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "GammaRegressor",  # TypeError: Object of type HalfGammaLoss is not JSON serializable
-    "GaussianProcessRegressor",  # TypeError: Object of type Product is not JSON serializable
-    "GradientBoostingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingRegressor",  # TypeError: Object of type HalfSquaredError is not JSON serializable
-    "IsotonicRegression",  # TypeError: Object of type interp1d is not JSON serializable
-    "MultiOutputRegressor",  # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
-    "PoissonRegressor",  # TypeError: Object of type HalfPoissonLoss is not JSON serializable
-    "RandomForestRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "RANSACRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
-    "RegressorChain",  # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "StackingRegressor",  # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
-    "TransformedTargetRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
-    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "TweedieRegressor",  # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
-    "VotingRegressor",  # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "AdaBoostRegressor", #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "BaggingRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "DecisionTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreesRegressor", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "GammaRegressor", # TypeError: Object of type HalfGammaLoss is not JSON serializable
+    "GaussianProcessRegressor", # TypeError: Object of type Product is not JSON serializable
+    "GradientBoostingRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingRegressor", # TypeError: Object of type HalfSquaredError is not JSON serializable
+    "IsotonicRegression", # TypeError: Object of type interp1d is not JSON serializable
+    "MultiOutputRegressor", # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
+    "PoissonRegressor", # TypeError: Object of type HalfPoissonLoss is not JSON serializable
+    "RandomForestRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "RANSACRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
+    "RegressorChain", # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "StackingRegressor", # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "TransformedTargetRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
+    "DecisionTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
+    "TweedieRegressor", # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
+    "VotingRegressor", # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
-    "AdaBoostClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "BaggingClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "CalibratedClassifierCV",  # TypeError: Object of type _CalibratedClassifier is not JSON serializable
-    "ClassifierChain",  # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreesClassifier",  # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
-    "FixedThresholdClassifier",  # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "GaussianProcessClassifier",  # TypeError: Object of type OneVsRestClassifier is not JSON serializable
-    "GradientBoostingClassifier",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingClassifier",  # TypeError: Object of type TreePredictor is not JSON serializable
-    "KNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
-    "MLPClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "MultiOutputClassifier",  # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsOneClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsRestClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OutputCodeClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "PassiveAggressiveClassifier",  # TypeError: Object of type Hinge is not JSON serializable
-    "Perceptron",  # TypeError: Object of type Hinge is not JSON serializable
-    "RadiusNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
-    "RandomForestClassifier",  #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "SGDClassifier",  # TypeError: Object of type Hinge is not JSON serializable
-    "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
-    "StackingClassifier",  # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
-    "TunedThresholdClassifierCV",  # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
-    "VotingClassifier",  # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "AdaBoostClassifier", # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "BaggingClassifier", # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "CalibratedClassifierCV", # TypeError: Object of type _CalibratedClassifier is not JSON serializable
+    "ClassifierChain", # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "DecisionTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
+    "ExtraTreeClassifier", # TypeError: Object of type _Tree is not JSON serializable
+    "ExtraTreesClassifier", # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
+    "FixedThresholdClassifier", # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "GaussianProcessClassifier", # TypeError: Object of type OneVsRestClassifier is not JSON serializable
+    "GradientBoostingClassifier", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingClassifier", # TypeError: Object of type TreePredictor is not JSON serializable
+    "KNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
+    "MLPClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "MultiOutputClassifier", # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsOneClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsRestClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OutputCodeClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "PassiveAggressiveClassifier", # TypeError: Object of type Hinge is not JSON serializable
+    "Perceptron", # TypeError: Object of type Hinge is not JSON serializable
+    "RadiusNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
+    "RandomForestClassifier", #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "RidgeClassifierCV", # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "SGDClassifier", # TypeError: Object of type Hinge is not JSON serializable
+    "SelfTrainingClassifier", # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
+    "StackingClassifier", # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "TunedThresholdClassifierCV", # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
+    "VotingClassifier", # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
     # Clusters:
-    "Birch",  # TypeError: Object of type _CFNode is not JSON serializable
-    "BisectingKMeans",  # TypeError: Object of type _BisectingTree is not JSON serializable
-    "FeatureAgglomeration",  # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
-    "HDBSCAN",  # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
+    "Birch", # TypeError: Object of type _CFNode is not JSON serializable
+    "BisectingKMeans", # TypeError: Object of type _BisectingTree is not JSON serializable
+    "FeatureAgglomeration", # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
+    "HDBSCAN", # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
     # Transformers:
-    "ColumnTransformer",  # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
-    "DictVectorizer",  # TypeError: Object of type type is not JSON serializable (in params)
-    "FeatureHasher",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "FeatureUnion",  # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
-    "GaussianRandomProjection",  # TypeError: Object of type RandomState is not JSON serializable
-    "GenericUnivariateSelect",  # TypeError: Object of type function is not JSON serializable
-    "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap",  # TypeError: Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer",  # TypeError: Object of type OneHotEncoder is not JSON serializable
-    "KNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
-    "KernelPCA",  # TypeError: Object of type KernelCenterer is not JSON serializable
-    "LatentDirichletAllocation",  # TypeError: Object of type RandomState is not JSON serializable
-    "LinearDiscriminantAnalysis",  # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
-    "LocallyLinearEmbedding",  # TypeError: Object of type NearestNeighbors is not JSON serializable"
-    "LabelBinarizer",  # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "LabelEncoder",  # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
-    "MultiLabelBinarizer",  # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "NeighborhoodComponentsAnalysis",  # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
-    "OneHotEncoder",  # TypeError: Object of type type is not JSON serializable
-    "OrdinalEncoder",  # TypeError: Object of type type is not JSON serializable
-    "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer",  # TypeError: Object of type StandardScaler is not JSON serializable
-    "RFE",  # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
-    "RFECV",  # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
-    "RadiusNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "SelectFdr",  # TypeError: Object of type function is not JSON serializable
-    "SelectFpr",  # TypeError: Object of type function is not JSON serializable
-    "SelectFromModel",  # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
-    "SelectFwe",  # TypeError: Object of type function is not JSON serializable
-    "SelectKBest",  # TypeError: Object of type function is not JSON serializable
-    "SelectPercentile",  # TypeError: Object of type function is not JSON serializable
-    "SequentialFeatureSelector",  # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
-    "SimpleImputer",  # TypeError: Object of type Float64DType is not JSON serializable
-    "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
-    "SparseCoder",  # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
-    "SparseRandomProjection",  # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
-    "SplineTransformer",  # TypeError: Object of type BSpline is not JSON serializable
-    "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
-    "TfidfTransformer",  # ValueError
+    "ColumnTransformer", # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
+    "DictVectorizer", # TypeError: Object of type type is not JSON serializable (in params)
+    "FeatureHasher", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "FeatureUnion", # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
+    "GaussianRandomProjection", # TypeError: Object of type RandomState is not JSON serializable
+    "GenericUnivariateSelect", # TypeError: Object of type function is not JSON serializable
+    "HashingVectorizer", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "Isomap", # TypeError: Object of type KernelPCA is not JSON serializable
+    "KBinsDiscretizer", # TypeError: Object of type OneHotEncoder is not JSON serializable
+    "KNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
+    "KernelPCA", # TypeError: Object of type KernelCenterer is not JSON serializable
+    "LatentDirichletAllocation", # TypeError: Object of type RandomState is not JSON serializable
+    "LinearDiscriminantAnalysis", # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
+    "LocallyLinearEmbedding", # TypeError: Object of type NearestNeighbors is not JSON serializable"
+    "LabelBinarizer", # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "LabelEncoder", # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
+    "MultiLabelBinarizer", # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "NeighborhoodComponentsAnalysis", # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
+    "OneHotEncoder", # TypeError: Object of type type is not JSON serializable
+    "OrdinalEncoder", # TypeError: Object of type type is not JSON serializable
+    "PatchExtractor", # ValueError: not enough values to unpack (expected 3, got 2)
+    "PowerTransformer", # TypeError: Object of type StandardScaler is not JSON serializable
+    "RFE", # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
+    "RFECV", # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
+    "RadiusNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
+    "RandomTreesEmbedding", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "SelectFdr", # TypeError: Object of type function is not JSON serializable
+    "SelectFpr", # TypeError: Object of type function is not JSON serializable
+    "SelectFromModel", # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
+    "SelectFwe", # TypeError: Object of type function is not JSON serializable
+    "SelectKBest", # TypeError: Object of type function is not JSON serializable
+    "SelectPercentile", # TypeError: Object of type function is not JSON serializable
+    "SequentialFeatureSelector", # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
+    "SimpleImputer", # TypeError: Object of type Float64DType is not JSON serializable
+    "SkewedChi2Sampler", # ValueError: X may not contain entries smaller than -skewedness.
+    "SparseCoder", # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
+    "SparseRandomProjection", # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
+    "SplineTransformer", # TypeError: Object of type BSpline is not JSON serializable
+    "TargetEncoder", # ValueError: Expected array-like (array or non-string sequence), got None
+    "TfidfTransformer", # ValueError
     # Others:
-    "BayesianGaussianMixture",  # TypeError: Object of type ndarray is not JSON serializable
-    "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    "FrozenEstimator",  # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
-    "GridSearchCV",  # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "KernelDensity",  # TypeError: Object of type KDTree is not JSON serializable
-    "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
-    "Pipeline",  # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
-    "RandomizedSearchCV",  # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
-    "SGDOneClassSVM",  # TypeError: Object of type Hinge is not JSON serializable
-    "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+    "BayesianGaussianMixture", # TypeError: Object of type ndarray is not JSON serializable
+    "CountVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+    "FrozenEstimator", # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
+    "GridSearchCV", # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
+    "IsolationForest", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "KernelDensity", # TypeError: Object of type KDTree is not JSON serializable
+    "LocalOutlierFactor", # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
+    "Pipeline", # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
+    "RandomizedSearchCV", # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
+    "SGDOneClassSVM", # TypeError: Object of type Hinge is not JSON serializable
+    "TfidfVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
 ]
 
 # Dictionary of attribute exceptions

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -22,112 +22,112 @@ ALL_ESTIMATORS = {
 
 NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
-    "AdaBoostRegressor",  #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "BaggingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreesRegressor",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "GammaRegressor",  # TypeError: Object of type HalfGammaLoss is not JSON serializable
-    "GaussianProcessRegressor",  # TypeError: Object of type Product is not JSON serializable
-    "GradientBoostingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingRegressor",  # TypeError: Object of type HalfSquaredError is not JSON serializable
-    "IsotonicRegression",  # TypeError: Object of type interp1d is not JSON serializable
-    "MultiOutputRegressor",  # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
-    "PoissonRegressor",  # TypeError: Object of type HalfPoissonLoss is not JSON serializable
-    "RandomForestRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "RANSACRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
-    "RegressorChain",  # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "StackingRegressor",  # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
-    "TransformedTargetRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
-    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "TweedieRegressor",  # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
-    "VotingRegressor",  # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "AdaBoostRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "BaggingRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "DecisionTreeRegressor",  # Object of type Tree is not JSON serializable
+    "ExtraTreeRegressor",  # Object of type Tree is not JSON serializable
+    "ExtraTreesRegressor",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "GammaRegressor",  # Object of type HalfGammaLoss is not JSON serializable
+    "GaussianProcessRegressor",  # Object of type Product is not JSON serializable
+    "GradientBoostingRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingRegressor",  # Object of type HalfSquaredError is not JSON serializable
+    "IsotonicRegression",  # Object of type interp1d is not JSON serializable
+    "MultiOutputRegressor",  # MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
+    "PoissonRegressor",  # Object of type HalfPoissonLoss is not JSON serializable
+    "RandomForestRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "RANSACRegressor",  # Object of type LinearRegression is not JSON serializable
+    "RegressorChain",  # _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "StackingRegressor",  # StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "TransformedTargetRegressor",  # Object of type LinearRegression is not JSON serializable
+    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
+    "TweedieRegressor",  # Object of type HalfTweedieLossIdentity is not JSON serializable
+    "VotingRegressor",  # VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
-    "AdaBoostClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "BaggingClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "CalibratedClassifierCV",  # TypeError: Object of type _CalibratedClassifier is not JSON serializable
-    "ClassifierChain",  # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "ExtraTreesClassifier",  # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
-    "FixedThresholdClassifier",  # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "GaussianProcessClassifier",  # TypeError: Object of type OneVsRestClassifier is not JSON serializable
-    "GradientBoostingClassifier",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingClassifier",  # TypeError: Object of type TreePredictor is not JSON serializable
-    "KNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
-    "MLPClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "MultiOutputClassifier",  # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsOneClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsRestClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OutputCodeClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "PassiveAggressiveClassifier",  # TypeError: Object of type Hinge is not JSON serializable
-    "Perceptron",  # TypeError: Object of type Hinge is not JSON serializable
-    "RadiusNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
-    "RandomForestClassifier",  #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV",  # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "SGDClassifier",  # TypeError: Object of type Hinge is not JSON serializable
+    "AdaBoostClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
+    "BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
+    "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
+    "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
+    "ExtraTreeClassifier",  # Object of type _Tree is not JSON serializable
+    "ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
+    "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
+    "GradientBoostingClassifier",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingClassifier",  # Object of type TreePredictor is not JSON serializable
+    "KNeighborsClassifier",  # Object of type KDTree is not JSON serializable
+    "MLPClassifier",  # Object of type LabelBinarizer is not JSON serializable
+    "MultiOutputClassifier",  # MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsOneClassifier",  # OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsRestClassifier",  # OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OutputCodeClassifier",  # OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "PassiveAggressiveClassifier",  # Object of type Hinge is not JSON serializable
+    "Perceptron",  # Object of type Hinge is not JSON serializable
+    "RadiusNeighborsClassifier",  # Object of type KDTree is not JSON serializable
+    "RandomForestClassifier",  #  Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier",  # Object of type LabelBinarizer is not JSON serializable
+    "RidgeClassifierCV",  # Object of type LabelBinarizer is not JSON serializable
+    "SGDClassifier",  # Object of type Hinge is not JSON serializable
     "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
-    "StackingClassifier",  # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
-    "TunedThresholdClassifierCV",  # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
-    "VotingClassifier",  # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "StackingClassifier",  # StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "TunedThresholdClassifierCV",  # TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
+    "VotingClassifier",  # VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
     # Clusters:
-    "Birch",  # TypeError: Object of type _CFNode is not JSON serializable
-    "BisectingKMeans",  # TypeError: Object of type _BisectingTree is not JSON serializable
-    "FeatureAgglomeration",  # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
-    "HDBSCAN",  # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
+    "Birch",  # Object of type _CFNode is not JSON serializable
+    "BisectingKMeans",  # Object of type _BisectingTree is not JSON serializable
+    "FeatureAgglomeration",  # Object of type _ArrayFunctionDispatcher is not JSON serializable
+    "HDBSCAN",  # data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
     # Transformers:
-    "ColumnTransformer",  # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
-    "DictVectorizer",  # TypeError: Object of type type is not JSON serializable (in params)
+    "ColumnTransformer",  # ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
+    "DictVectorizer",  # Object of type type is not JSON serializable (in params)
     "FeatureHasher",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "FeatureUnion",  # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
-    "GaussianRandomProjection",  # TypeError: Object of type RandomState is not JSON serializable
-    "GenericUnivariateSelect",  # TypeError: Object of type function is not JSON serializable
+    "FeatureUnion",  # FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
+    "GaussianRandomProjection",  # Object of type RandomState is not JSON serializable
+    "GenericUnivariateSelect",  # Object of type function is not JSON serializable
     "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap",  # TypeError: Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer",  # TypeError: Object of type OneHotEncoder is not JSON serializable
-    "KNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
-    "KernelPCA",  # TypeError: Object of type KernelCenterer is not JSON serializable
-    "LatentDirichletAllocation",  # TypeError: Object of type RandomState is not JSON serializable
+    "Isomap",  # Object of type KernelPCA is not JSON serializable
+    "KBinsDiscretizer",  # Object of type OneHotEncoder is not JSON serializable
+    "KNeighborsTransformer",  # Object of type KDTree is not JSON serializable
+    "KernelPCA",  # Object of type KernelCenterer is not JSON serializable
+    "LatentDirichletAllocation",  # Object of type RandomState is not JSON serializable
     "LinearDiscriminantAnalysis",  # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
-    "LocallyLinearEmbedding",  # TypeError: Object of type NearestNeighbors is not JSON serializable"
-    "LabelBinarizer",  # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "LabelEncoder",  # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
-    "MultiLabelBinarizer",  # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "LocallyLinearEmbedding",  # Object of type NearestNeighbors is not JSON serializable"
+    "LabelBinarizer",  # LabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "LabelEncoder",  # LabelEncoder.fit() takes 2 positional arguments but 3 were given
+    "MultiLabelBinarizer",  # MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
     "NeighborhoodComponentsAnalysis",  # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
-    "OneHotEncoder",  # TypeError: Object of type type is not JSON serializable
-    "OrdinalEncoder",  # TypeError: Object of type type is not JSON serializable
+    "OneHotEncoder",  # Object of type type is not JSON serializable
+    "OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer",  # TypeError: Object of type StandardScaler is not JSON serializable
-    "RFE",  # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
-    "RFECV",  # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
-    "RadiusNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "SelectFdr",  # TypeError: Object of type function is not JSON serializable
-    "SelectFpr",  # TypeError: Object of type function is not JSON serializable
-    "SelectFromModel",  # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
-    "SelectFwe",  # TypeError: Object of type function is not JSON serializable
-    "SelectKBest",  # TypeError: Object of type function is not JSON serializable
-    "SelectPercentile",  # TypeError: Object of type function is not JSON serializable
-    "SequentialFeatureSelector",  # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
-    "SimpleImputer",  # TypeError: Object of type Float64DType is not JSON serializable
+    "PowerTransformer",  # Object of type StandardScaler is not JSON serializable
+    "RFE",  # RFE.__init__() missing 1 required positional argument: 'estimator'
+    "RFECV",  # RFECV.__init__() missing 1 required positional argument: 'estimator'
+    "RadiusNeighborsTransformer",  # Object of type KDTree is not JSON serializable
+    "RandomTreesEmbedding",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "SelectFdr",  # Object of type function is not JSON serializable
+    "SelectFpr",  # Object of type function is not JSON serializable
+    "SelectFromModel",  # SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
+    "SelectFwe",  # Object of type function is not JSON serializable
+    "SelectKBest",  # Object of type function is not JSON serializable
+    "SelectPercentile",  # Object of type function is not JSON serializable
+    "SequentialFeatureSelector",  # SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
+    "SimpleImputer",  # Object of type Float64DType is not JSON serializable
     "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
-    "SparseCoder",  # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
+    "SparseCoder",  # SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
     "SparseRandomProjection",  # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
-    "SplineTransformer",  # TypeError: Object of type BSpline is not JSON serializable
+    "SplineTransformer",  # Object of type BSpline is not JSON serializable
     "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
     "TfidfTransformer",  # ValueError
     # Others:
-    "BayesianGaussianMixture",  # TypeError: Object of type ndarray is not JSON serializable
+    "BayesianGaussianMixture",  # Object of type ndarray is not JSON serializable
     "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    "FrozenEstimator",  # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
-    "GridSearchCV",  # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "KernelDensity",  # TypeError: Object of type KDTree is not JSON serializable
+    "FrozenEstimator",  # FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
+    "GridSearchCV",  # GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
+    "IsolationForest",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "KernelDensity",  # Object of type KDTree is not JSON serializable
     "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
-    "Pipeline",  # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
-    "RandomizedSearchCV",  # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
-    "SGDOneClassSVM",  # TypeError: Object of type Hinge is not JSON serializable
+    "Pipeline",  # Pipeline.__init__() missing 1 required positional argument: 'steps'
+    "RandomizedSearchCV",  # RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
+    "SGDOneClassSVM",  # Object of type Hinge is not JSON serializable
     "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
 ]
 
@@ -187,12 +187,11 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "KNNImputer": ["_mask_fit_X", "_valid_mask"],
     "KNeighborsTransformer": ["_fit_method", "_tree"],
     "PowerTransformer": ["_scaler"],
-    "RadiusNeighborsTransformer": ["_fit_method"],
+    "RadiusNeighborsTransformer": ["_fit_method", "_tree"],
     "SimpleImputer": ["_fit_dtype"],
     "MiniBatchNMF": ["_n_components", "_transform_max_iter", "_beta_loss", "_gamma"],
     "MissingIndicator": ["_n_features", "_precomputed"],
     "PolynomialFeatures": ["_max_degree", "_n_out_full", "_min_degree"],
-    "RadiusNeighborsTransformer": ["_tree"],
     "PLSSVD": ["_x_mean", "_x_std"],
     # Others:
     "OneClassSVM": ["_sparse", "_n_support", "_probA", "_probB", "_gamma"],

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -24,112 +24,112 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
     "AdaBoostRegressor",  #  TypeError: Object of type DecisionTreeRegressor is not JSON serializable
     "BaggingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor", # TypeError: Object of type Tree is not JSON serializable
-    "ExtraTreesRegressor", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "GammaRegressor", # TypeError: Object of type HalfGammaLoss is not JSON serializable
-    "GaussianProcessRegressor", # TypeError: Object of type Product is not JSON serializable
-    "GradientBoostingRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingRegressor", # TypeError: Object of type HalfSquaredError is not JSON serializable
-    "IsotonicRegression", # TypeError: Object of type interp1d is not JSON serializable
-    "MultiOutputRegressor", # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
-    "PoissonRegressor", # TypeError: Object of type HalfPoissonLoss is not JSON serializable
-    "RandomForestRegressor", # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "RANSACRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
-    "RegressorChain", # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "StackingRegressor", # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
-    "TransformedTargetRegressor", # TypeError: Object of type LinearRegression is not JSON serializable
+    "DecisionTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreeRegressor",  # TypeError: Object of type Tree is not JSON serializable
+    "ExtraTreesRegressor",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "GammaRegressor",  # TypeError: Object of type HalfGammaLoss is not JSON serializable
+    "GaussianProcessRegressor",  # TypeError: Object of type Product is not JSON serializable
+    "GradientBoostingRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "HistGradientBoostingRegressor",  # TypeError: Object of type HalfSquaredError is not JSON serializable
+    "IsotonicRegression",  # TypeError: Object of type interp1d is not JSON serializable
+    "MultiOutputRegressor",  # TypeError: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
+    "PoissonRegressor",  # TypeError: Object of type HalfPoissonLoss is not JSON serializable
+    "RandomForestRegressor",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
+    "RANSACRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
+    "RegressorChain",  # TypeError: _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "StackingRegressor",  # TypeError: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "TransformedTargetRegressor",  # TypeError: Object of type LinearRegression is not JSON serializable
     "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
-    "TweedieRegressor", # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
-    "VotingRegressor", # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
+    "TweedieRegressor",  # TypeError: Object of type HalfTweedieLossIdentity is not JSON serializable
+    "VotingRegressor",  # TypeError: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
     "AdaBoostClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
     "BaggingClassifier",  # TypeError: Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # TypeError: Object of type _CalibratedClassifier is not JSON serializable
-    "ClassifierChain", # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
+    "ClassifierChain",  # TypeError: ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
     "DecisionTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
     "ExtraTreeClassifier",  # TypeError: Object of type _Tree is not JSON serializable
     "ExtraTreesClassifier",  # TypeError: Object of type ExtraTreeClassifier is not JSON serializable
-    "FixedThresholdClassifier", # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "FixedThresholdClassifier",  # TypeError: FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # TypeError: Object of type OneVsRestClassifier is not JSON serializable
     "GradientBoostingClassifier",  # TypeError: Object of type DecisionTreeRegressor is not JSON serializable
-    "HistGradientBoostingClassifier", # TypeError: Object of type TreePredictor is not JSON serializable
-    "KNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
-    "MLPClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "MultiOutputClassifier", # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsOneClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OneVsRestClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "OutputCodeClassifier", # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
-    "PassiveAggressiveClassifier", # TypeError: Object of type Hinge is not JSON serializable
-    "Perceptron", # TypeError: Object of type Hinge is not JSON serializable
-    "RadiusNeighborsClassifier", # TypeError: Object of type KDTree is not JSON serializable
-    "RandomForestClassifier", #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV", # TypeError: Object of type LabelBinarizer is not JSON serializable
-    "SGDClassifier", # TypeError: Object of type Hinge is not JSON serializable
-    "SelfTrainingClassifier", # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
-    "StackingClassifier", # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
-    "TunedThresholdClassifierCV", # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
-    "VotingClassifier", # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "HistGradientBoostingClassifier",  # TypeError: Object of type TreePredictor is not JSON serializable
+    "KNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
+    "MLPClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "MultiOutputClassifier",  # TypeError: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsOneClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OneVsRestClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "OutputCodeClassifier",  # TypeError: OneVsOneClassifier.__init__() missing 1 required positional argument: 'estimator'
+    "PassiveAggressiveClassifier",  # TypeError: Object of type Hinge is not JSON serializable
+    "Perceptron",  # TypeError: Object of type Hinge is not JSON serializable
+    "RadiusNeighborsClassifier",  # TypeError: Object of type KDTree is not JSON serializable
+    "RandomForestClassifier",  #  TypeError: Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "RidgeClassifierCV",  # TypeError: Object of type LabelBinarizer is not JSON serializable
+    "SGDClassifier",  # TypeError: Object of type Hinge is not JSON serializable
+    "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
+    "StackingClassifier",  # TypeError: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
+    "TunedThresholdClassifierCV",  # TypeError: TunedThresholdClassifierCV.__init__() missing 1 required positional argument: 'estimator'
+    "VotingClassifier",  # TypeError: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'
     # Clusters:
-    "Birch", # TypeError: Object of type _CFNode is not JSON serializable
-    "BisectingKMeans", # TypeError: Object of type _BisectingTree is not JSON serializable
-    "FeatureAgglomeration", # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
-    "HDBSCAN", # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
+    "Birch",  # TypeError: Object of type _CFNode is not JSON serializable
+    "BisectingKMeans",  # TypeError: Object of type _BisectingTree is not JSON serializable
+    "FeatureAgglomeration",  # TypeError: Object of type _ArrayFunctionDispatcher is not JSON serializable
+    "HDBSCAN",  # TypeError: data type "[('left_node', '<i8'), ('right_node', '<i8'), ('value', '<f8'), ('cluster_size', '<i8')]" not understood
     # Transformers:
-    "ColumnTransformer", # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
-    "DictVectorizer", # TypeError: Object of type type is not JSON serializable (in params)
-    "FeatureHasher", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "FeatureUnion", # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
-    "GaussianRandomProjection", # TypeError: Object of type RandomState is not JSON serializable
-    "GenericUnivariateSelect", # TypeError: Object of type function is not JSON serializable
-    "HashingVectorizer", # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap", # TypeError: Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer", # TypeError: Object of type OneHotEncoder is not JSON serializable
-    "KNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
-    "KernelPCA", # TypeError: Object of type KernelCenterer is not JSON serializable
-    "LatentDirichletAllocation", # TypeError: Object of type RandomState is not JSON serializable
-    "LinearDiscriminantAnalysis", # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
-    "LocallyLinearEmbedding", # TypeError: Object of type NearestNeighbors is not JSON serializable"
-    "LabelBinarizer", # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "LabelEncoder", # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
-    "MultiLabelBinarizer", # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
-    "NeighborhoodComponentsAnalysis", # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
-    "OneHotEncoder", # TypeError: Object of type type is not JSON serializable
-    "OrdinalEncoder", # TypeError: Object of type type is not JSON serializable
-    "PatchExtractor", # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer", # TypeError: Object of type StandardScaler is not JSON serializable
-    "RFE", # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
-    "RFECV", # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
-    "RadiusNeighborsTransformer", # TypeError: Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "SelectFdr", # TypeError: Object of type function is not JSON serializable
-    "SelectFpr", # TypeError: Object of type function is not JSON serializable
-    "SelectFromModel", # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
-    "SelectFwe", # TypeError: Object of type function is not JSON serializable
-    "SelectKBest", # TypeError: Object of type function is not JSON serializable
-    "SelectPercentile", # TypeError: Object of type function is not JSON serializable
-    "SequentialFeatureSelector", # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
-    "SimpleImputer", # TypeError: Object of type Float64DType is not JSON serializable
-    "SkewedChi2Sampler", # ValueError: X may not contain entries smaller than -skewedness.
-    "SparseCoder", # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
-    "SparseRandomProjection", # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
-    "SplineTransformer", # TypeError: Object of type BSpline is not JSON serializable
-    "TargetEncoder", # ValueError: Expected array-like (array or non-string sequence), got None
-    "TfidfTransformer", # ValueError
+    "ColumnTransformer",  # TypeError: ColumnTransformer.__init__() missing 1 required positional argument: 'transformers'
+    "DictVectorizer",  # TypeError: Object of type type is not JSON serializable (in params)
+    "FeatureHasher",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "FeatureUnion",  # TypeError: FeatureUnion.__init__() missing 1 required positional argument: 'transformer_list'
+    "GaussianRandomProjection",  # TypeError: Object of type RandomState is not JSON serializable
+    "GenericUnivariateSelect",  # TypeError: Object of type function is not JSON serializable
+    "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
+    "Isomap",  # TypeError: Object of type KernelPCA is not JSON serializable
+    "KBinsDiscretizer",  # TypeError: Object of type OneHotEncoder is not JSON serializable
+    "KNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
+    "KernelPCA",  # TypeError: Object of type KernelCenterer is not JSON serializable
+    "LatentDirichletAllocation",  # TypeError: Object of type RandomState is not JSON serializable
+    "LinearDiscriminantAnalysis",  # ValueError: This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
+    "LocallyLinearEmbedding",  # TypeError: Object of type NearestNeighbors is not JSON serializable"
+    "LabelBinarizer",  # TypeError: LabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "LabelEncoder",  # TypeError: LabelEncoder.fit() takes 2 positional arguments but 3 were given
+    "MultiLabelBinarizer",  # TypeError: MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
+    "NeighborhoodComponentsAnalysis",  # ValueError: This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
+    "OneHotEncoder",  # TypeError: Object of type type is not JSON serializable
+    "OrdinalEncoder",  # TypeError: Object of type type is not JSON serializable
+    "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
+    "PowerTransformer",  # TypeError: Object of type StandardScaler is not JSON serializable
+    "RFE",  # TypeError: RFE.__init__() missing 1 required positional argument: 'estimator'
+    "RFECV",  # TypeError: RFECV.__init__() missing 1 required positional argument: 'estimator'
+    "RadiusNeighborsTransformer",  # TypeError: Object of type KDTree is not JSON serializable
+    "RandomTreesEmbedding",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "SelectFdr",  # TypeError: Object of type function is not JSON serializable
+    "SelectFpr",  # TypeError: Object of type function is not JSON serializable
+    "SelectFromModel",  # TypeError: SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
+    "SelectFwe",  # TypeError: Object of type function is not JSON serializable
+    "SelectKBest",  # TypeError: Object of type function is not JSON serializable
+    "SelectPercentile",  # TypeError: Object of type function is not JSON serializable
+    "SequentialFeatureSelector",  # TypeError: SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
+    "SimpleImputer",  # TypeError: Object of type Float64DType is not JSON serializable
+    "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
+    "SparseCoder",  # TypeError: SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
+    "SparseRandomProjection",  # ValueError: eps=0.100000 and n_samples=50 lead to a target dimension of 3353 which is larger than the original space with n_features=5
+    "SplineTransformer",  # TypeError: Object of type BSpline is not JSON serializable
+    "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
+    "TfidfTransformer",  # ValueError
     # Others:
-    "BayesianGaussianMixture", # TypeError: Object of type ndarray is not JSON serializable
-    "CountVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    "FrozenEstimator", # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
-    "GridSearchCV", # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest", # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
-    "KernelDensity", # TypeError: Object of type KDTree is not JSON serializable
-    "LocalOutlierFactor", # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
-    "Pipeline", # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
-    "RandomizedSearchCV", # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
-    "SGDOneClassSVM", # TypeError: Object of type Hinge is not JSON serializable
-    "TfidfVectorizer", # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    ]
+    "BayesianGaussianMixture",  # TypeError: Object of type ndarray is not JSON serializable
+    "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+    "FrozenEstimator",  # TypeError: FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
+    "GridSearchCV",  # TypeError: GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
+    "IsolationForest",  # TypeError: Object of type ExtraTreeRegressor is not JSON serializable
+    "KernelDensity",  # TypeError: Object of type KDTree is not JSON serializable
+    "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
+    "Pipeline",  # TypeError: Pipeline.__init__() missing 1 required positional argument: 'steps'
+    "RandomizedSearchCV",  # TypeError: RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
+    "SGDOneClassSVM",  # TypeError: Object of type Hinge is not JSON serializable
+    "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
+]
 
 # Dictionary of attribute exceptions
 ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
@@ -161,8 +161,12 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "MiniBatchKMeans": ["_n_threads"],
     # Classifiers:
     "DummyClassifier": ["_strategy"],
-    "HistGradientBoostingClassifier": ["_preprocessor", "_baseline_prediction", "_predictors"],
-    "MLPClassifier":["_label_binarizer"],
+    "HistGradientBoostingClassifier": [
+        "_preprocessor",
+        "_baseline_prediction",
+        "_predictors",
+    ],
+    "MLPClassifier": ["_label_binarizer"],
     "NuSVC": ["_sparse", "_n_support", "_probA", "_probB", "_gamma"],
     "KNeighborsClassifier": ["_fit_method", "_fit_X", "_y", "_tree"],
     "RadiusNeighborsClassifier": ["_fit_method", "_fit_X", "_y", "_tree"],
@@ -192,7 +196,6 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "PLSSVD": ["_x_mean", "_x_std"],
     # Others:
     "OneClassSVM": ["_sparse", "_n_support", "_probA", "_probB", "_gamma"],
-
 }
 
 
@@ -215,7 +218,9 @@ class SklearnSerializer(ModelSerializer):
     """
 
     @staticmethod
-    def all_estimators(type_filter: Optional[str] = None) -> List[Tuple[str, Type[BaseEstimator]]]:
+    def all_estimators(
+        type_filter: Optional[str] = None,
+    ) -> List[Tuple[str, Type[BaseEstimator]]]:
         """
         Get all scikit-learn supported estimators.
 
@@ -225,10 +230,11 @@ class SklearnSerializer(ModelSerializer):
             A dictionary of all scikit-learn supported estimators.
         """
 
-        return [(name, cls)
-                for name, cls in all_estimators(type_filter=type_filter)
-                if name not in NOT_SUPPORTED_ESTIMATORS
-                ]
+        return [
+            (name, cls)
+            for name, cls in all_estimators(type_filter=type_filter)
+            if name not in NOT_SUPPORTED_ESTIMATORS
+        ]
 
     @staticmethod
     def _convert_to_serializable_types(value: Any) -> Any:
@@ -253,7 +259,10 @@ class SklearnSerializer(ModelSerializer):
             # to guarantee compatibility with JSON serialization and deserialization.
             # NOTE: This ensures that LogisticRegressionCV works, but to put back the original
             # types we need to convert the keys back to the original types (done on fit).
-            return {str(k): SklearnSerializer._convert_to_serializable_types(v) for k, v in value.items()}
+            return {
+                str(k): SklearnSerializer._convert_to_serializable_types(v)
+                for k, v in value.items()
+            }
         if isinstance(value, (np.ndarray, List)):
             return SklearnSerializer._array_to_list(value)
         if isinstance(value, _csr.csr_matrix):
@@ -471,13 +480,11 @@ class SklearnSerializer(ModelSerializer):
             if isinstance(value, np.ndarray)  # Only include NumPy arrays
         }
 
-        attribute_types_map = dict(
-            zip(filtered_attribute_keys, attribute_types)
-        )
+        attribute_types_map = dict(zip(filtered_attribute_keys, attribute_types))
         # Print debug information
-        #print("--------", model.__class__.__name__, "--------")
-        #print(attribute_types_map)
-        #print(attribute_dtypes_map)
+        # print("--------", model.__class__.__name__, "--------")
+        # print(attribute_types_map)
+        # print(attribute_dtypes_map)
 
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -305,6 +305,15 @@ class SklearnSerializer(ModelSerializer):
         """
         # Base case: if attr_type is not a list, convert value based on attr_type
         if isinstance(attr_type, str):
+            type_map = {
+                "int": int,
+                "int64": np.int64,
+                "int32": np.int32,
+                "float": float,
+                "float64": np.float64,
+                "str": str,
+                "tuple": tuple,
+            }
             if attr_type == "csr_matrix":
                 # Ensure all sparse matrix components are of correct dtype
                 return csr_matrix(
@@ -317,20 +326,8 @@ class SklearnSerializer(ModelSerializer):
                 )
             elif attr_type == "ndarray":
                 return np.array(value, dtype=attr_dtype or np.float64)
-            elif attr_type == "int":
-                return int(value)
-            elif attr_type == "int64":
-                return np.int64(value)
-            elif attr_type == "int32":
-                return np.int32(value)
-            elif attr_type == "float":
-                return float(value)
-            elif attr_type == "float64":
-                return np.float64(value)
-            elif attr_type == "str":
-                return str(value)
-            elif attr_type == "tuple":
-                return tuple(value)
+            elif attr_type in type_map:
+                return type_map[attr_type](value)
             # Add other types as needed
             return value  # Return as-is if no specific conversion is needed
         # Recursive case: if attr_type is a list, process each element in value

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -20,13 +20,26 @@ ALL_ESTIMATORS = {
     name: cls for name, cls in all_estimators() if issubclass(cls, BaseEstimator)
 }
 
-SUPPORTED_ESTIMATORS: list[str] = ["BernoulliNB","ComplementNB","DummyClassifier",  
-                                   "GaussianNB", "GradientBoostingRegressor",
-                                   "Lasso", "LinearDiscriminantAnalysis",
-                                   "LinearRegression", "LogisticRegression",
-                                   "KMeans", "MLPRegressor", "MultinomialNB",
-                                   "PCA", "PLSRegression", "QuadraticDiscriminantAnalysis",
-                                   "Ridge", "SVC", "SVR"]
+SUPPORTED_ESTIMATORS: list[str] = [
+    "BernoulliNB",
+    "ComplementNB",
+    "DummyClassifier",
+    "GaussianNB",
+    "GradientBoostingRegressor",
+    "Lasso",
+    "LinearDiscriminantAnalysis",
+    "LinearRegression",
+    "LogisticRegression",
+    "KMeans",
+    "MLPRegressor",
+    "MultinomialNB",
+    "PCA",
+    "PLSRegression",
+    "QuadraticDiscriminantAnalysis",
+    "Ridge",
+    "SVC",
+    "SVR",
+]
 
 # Dictionary of attribute exceptions
 ATTRIBUTE_EXCEPTIONS: Dict[str, list] = {
@@ -278,8 +291,8 @@ class SklearnSerializer(ModelSerializer):
         # There are some attributes that are removed in the previous filter according to the
         # sklearn documentation.
         # However, they are still needed in the serialized model so we add them to the list.
-        filtered_attribute_keys = (
-            filtered_attribute_keys + ATTRIBUTE_EXCEPTIONS.get(model.__class__.__name__, [])
+        filtered_attribute_keys = filtered_attribute_keys + ATTRIBUTE_EXCEPTIONS.get(
+            model.__class__.__name__, []
         )
 
         attribute_values = [getattr(model, key) for key in filtered_attribute_keys]

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -1,0 +1,46 @@
+import pytest
+import random
+from sklearn.utils.discovery import all_estimators
+from sklearn.datasets import make_blobs
+from sklearn.feature_extraction import FeatureHasher
+from openmodels.test_helpers import run_test_model
+from openmodels.serializers.sklearn_serializer import NOT_SUPPORTED_ESTIMATORS
+
+# Get all cluster estimators, filtering out not supported clusters
+CLUSTERS = [
+    cls for name, cls in all_estimators(type_filter="cluster")
+    if name not in NOT_SUPPORTED_ESTIMATORS
+]
+
+@pytest.fixture(scope="module")
+def data():
+    # Generate test data
+    x, _ = make_blobs(
+        n_samples=30,
+        n_features=4,
+        centers=3,
+        random_state=42,
+    )
+
+    feature_hasher = FeatureHasher(n_features=4)
+    features = []
+    for _ in range(0, 100):
+        features.append(
+            {
+                "a": random.randint(0, 2),
+                "b": random.randint(3, 5),
+                "c": random.randint(6, 8),
+            }
+        )
+    x_sparse = feature_hasher.transform(iter(features))
+
+    return x, x_sparse
+
+
+@pytest.mark.parametrize("Cluster", CLUSTERS)
+def test_clusterer_fit_predict(Cluster, data):
+    x, x_sparse = data
+    cluster = Cluster()
+
+    # Run the test model
+    run_test_model(cluster, x, None, x_sparse, None, f"{Cluster.__name__.lower()}.json")

--- a/test/test_others.py
+++ b/test/test_others.py
@@ -3,10 +3,16 @@ from sklearn.utils.discovery import all_estimators
 from sklearn.datasets import make_classification
 from openmodels.test_helpers import run_test_model
 from openmodels.serializers.sklearn_serializer import NOT_SUPPORTED_ESTIMATORS
+from test.test_classification import CLASSIFIERS
+from test.test_clustering import CLUSTERS
+from test.test_regression import REGRESSORS
+from test.test_transformation import TRANSFORMERS
 
-# Get all classifier estimators, filtering out not supported classifiers
-CLASSIFIERS = [cls for name, cls in all_estimators(type_filter="classifier")
-        if name not in NOT_SUPPORTED_ESTIMATORS]
+# Get all other estimators, filtering out not supported
+OTHERS = [cls for name, cls in all_estimators()
+        if cls not in CLASSIFIERS + CLUSTERS + REGRESSORS + TRANSFORMERS
+        and name not in NOT_SUPPORTED_ESTIMATORS
+        ]
 
 # Define constants
 N_SAMPLES = 50
@@ -39,16 +45,11 @@ def data():
 
     return x, y
 
-@pytest.mark.parametrize("Classifier", CLASSIFIERS)
-def test_classifier(Classifier, data):
+@pytest.mark.parametrize("Others", OTHERS)
+def test_others(Others, data):
     x, y = data
-    classifier = Classifier()
-
-    abs = False
-
-    if Classifier.__name__ in ["CategoricalNB", "ComplementNB", "MultinomialNB"]:
-        abs = True
+    others = Others()
     
     # Run the test model
-    run_test_model(classifier, x, y, None, None, f"{Classifier.__name__.lower()}.json", abs)
+    run_test_model(others, x, y, None, None, f"{Others.__name__.lower()}.json")
  

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -55,6 +55,8 @@ def test_regressor(Regressor, data):
         y = y / np.std(y)
         if y.ndim == 1:
             y = y.reshape(-1, 1)
+        assert not np.isnan(x).any()
+        assert not np.isinf(x).any()
     elif Regressor.__name__ in ["MultiTaskElasticNet", "MultiTaskElasticNetCV", "MultiTaskLasso", "MultiTaskLassoCV"]:
         x, y = make_regression(n_samples=50, n_features=3, n_targets=2, random_state=42)
         x_sparse = None

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -52,6 +52,7 @@ def test_regressor(Regressor, data):
         x_sparse = None
         y_sparse = None
     elif Regressor.__name__ == "PLSRegression":
+        y = y / np.std(y)
         if y.ndim == 1:
             y = y.reshape(-1, 1)
     elif Regressor.__name__ in ["MultiTaskElasticNet", "MultiTaskElasticNetCV", "MultiTaskLasso", "MultiTaskLassoCV"]:

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -52,11 +52,10 @@ def test_regressor(Regressor, data):
         x_sparse = None
         y_sparse = None
     elif Regressor.__name__ == "PLSRegression":
-        y = y / np.std(y)
-        if y.ndim == 1:
-            y = y.reshape(-1, 1)
-        assert not np.isnan(x).any()
-        assert not np.isinf(x).any()
+        x = [[0., 0., 1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
+        y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]] 
+        x_sparse = None
+        y_sparse = None
     elif Regressor.__name__ in ["MultiTaskElasticNet", "MultiTaskElasticNetCV", "MultiTaskLasso", "MultiTaskLassoCV"]:
         x, y = make_regression(n_samples=50, n_features=3, n_targets=2, random_state=42)
         x_sparse = None

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -17,7 +17,7 @@ def data():
         n_samples=50,
         n_features=3,
         n_informative=3,
-        random_state=0,
+        random_state=42,
         shuffle=False,
     )
 

--- a/test/test_transformation.py
+++ b/test/test_transformation.py
@@ -1,0 +1,74 @@
+import pytest
+import random
+import numpy as np
+from sklearn.utils.discovery import all_estimators
+from sklearn.datasets import make_classification
+from sklearn.feature_extraction import FeatureHasher
+from openmodels.test_helpers import run_test_model
+from openmodels.serializers.sklearn_serializer import NOT_SUPPORTED_ESTIMATORS
+
+# Get all transformer estimators, filtering out not supported ones
+TRANSFORMERS = [
+    cls for name, cls in all_estimators(type_filter="transformer")
+    if name not in NOT_SUPPORTED_ESTIMATORS
+]
+
+@pytest.fixture(scope="module")
+def data():
+    # Generate dense data
+    x, y = make_classification(
+        n_samples=50,
+        n_features=5,
+        n_classes=3,
+        n_informative=3,
+        n_redundant=0,
+        random_state=0,
+        shuffle=False,
+    )
+    # Generate sparse data
+    feature_hasher = FeatureHasher(n_features=5)
+    features = [
+        {
+            "a": random.randint(0, 2),
+            "b": random.randint(3, 5),
+            "c": random.randint(6, 8),
+        }
+        for _ in range(0, 100)
+    ]
+    x_sparse = feature_hasher.transform(iter(features))
+    return x, y, x_sparse
+
+@pytest.mark.parametrize("Transformer", TRANSFORMERS)
+def test_transformer(Transformer, data):
+    x, y, x_sparse = data
+
+    args = {}
+    if Transformer.__name__ in ["AdditiveChi2Sampler", "MiniBatchNMF", "LatentDirichletAllocation", "NMF"]:
+        x = np.abs(x)
+    
+    if Transformer.__name__ not in ["CCA", "GenericUnivariateSelect", "PLSCanonical", "PLSRegression", "PLSSVD", "SelectFdr", "SelectFpr", "SelectFwe", "SelectKBest", "SelectPercentile"]:
+        y = None
+    if Transformer.__name__ in ["CCA", "PLSCanonical"]:
+        args["n_components"] = 1
+    if Transformer.__name__ in ["FeatureHasher"]:
+        y = None
+        x = None
+        x_sparse = None
+    if Transformer.__name__ in ["DictVectorizer"]:
+        y = None
+        x = [{'foo': 1, 'bar': 2}, {'foo': 3, 'baz': 1}]
+        x_sparse = None
+    if Transformer.__name__ in ["GaussianRandomProjection"]:  
+        rng = np.random.RandomState(42)
+        x = rng.rand(25, 3000)
+        args["random_state"] = rng
+    if Transformer.__name__ in ["KernelCenterer"]:
+        from sklearn.metrics.pairwise import pairwise_kernels
+        X = [[ 1., -2.,  2.], [ -2.,  1.,  3.], [ 4.,  1., -2.]]
+        x = pairwise_kernels(X, metric="linear")
+    if Transformer.__name__ in ["PLSSVD"]:
+        args["n_components"] = 1
+
+    transformer = Transformer(**args)
+
+    run_test_model(transformer, x, y, x_sparse, None, f"{Transformer.__name__.lower()}.json")


### PR DESCRIPTION
**Description:**
This update refactors the scikit-learn serializer to dynamically load supported estimators using [sklearn.utils.discovery.all_estimators](https://scikit-learn.org/stable/modules/generated/sklearn.utils.discovery.all_estimators.html), improving maintainability and extensibility. The list of supported estimators is now managed via a global variable, and only those explicitly listed in SUPPORTED_ESTIMATORS.

Additionally, the logic for handling attribute exceptions is made safer by using .get() to avoid KeyError for estimators without exceptions. The deserialization process now uses the dynamically loaded estimator classes, ensuring compatibility with future scikit-learn releases.

**Key changes:**

Use [all_estimators()](https://github.com/scikit-learn/scikit-learn/blob/c5497b7f7/sklearn/utils/discovery.py#L22) to build a dictionary of all available estimator classes at import time (also for building the test).
Restrict supported estimators to those listed in SUPPORTED_ESTIMATORS.
Improved handling of attribute exceptions using .get() for safe access.
Cleaner and more robust deserialization logic using the dynamic estimator dictionary.

**References:**

[scikit-learn all_estimators documentation](https://scikit-learn.org/stable/modules/generated/sklearn.utils.discovery.all_estimators.html)
[scikit-learn estimator attributes](https://scikit-learn.org/stable/glossary.html#term-attributes)