### PR TITLE
Add Support for scikit-learn Tree Type Serialization/Deserialization

### DIFF
--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
-from sklearn.tree import _tree
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
@@ -233,7 +232,7 @@ class SklearnSerializer(ModelSerializer):
         ]
 
     @staticmethod
-    def _serialize_tree(tree: _tree.Tree) -> Dict[str, Any]:
+    def _serialize_tree(tree: Tree) -> Dict[str, Any]:
         """
         Serializes a sklearn.tree._tree.Tree object to a dictionary.
 
@@ -256,7 +255,7 @@ class SklearnSerializer(ModelSerializer):
         }
 
     @staticmethod
-    def _deserialize_tree(tree_data: Dict[str, Any]) -> _tree.Tree:
+    def _deserialize_tree(tree_data: Dict[str, Any]) -> Tree:
         """
         Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
         """
@@ -298,7 +297,7 @@ class SklearnSerializer(ModelSerializer):
         Any
             The serializable representation of the value.
         """
-        if isinstance(value, (_tree.Tree)):
+        if isinstance(value, (Tree)):
             # If the value is a Tree object, serialize it to a dictionary
             return SklearnSerializer._serialize_tree(value)
 


### PR DESCRIPTION
## Description

This PR introduces robust support for serializing and deserializing scikit-learn models that utilize the internal `_tree.Tree` structure, such as `DecisionTreeClassifier`, `DecisionTreeRegressor`, and related estimators. Previously, these models were excluded from serialization due to the non-JSON-serializable nature of the `Tree` object.

---

### Key Changes

- **Custom Tree Serialization:**  
  Added `_serialize_tree` and `_deserialize_tree` static methods to convert `sklearn.tree._tree.Tree` objects to and from dictionary representations, including all necessary state and dtype information.

- **Estimator Support List:**  
  Removed tree-based estimators (e.g., `DecisionTreeClassifier`, `DecisionTreeRegressor`, `ExtraTreeClassifier`, `ExtraTreeRegressor`) from the `NOT_SUPPORTED_ESTIMATORS` list, enabling their use with the OpenModels serialization framework.

- **Attribute Handling:**  
  Updated the attribute serialization/deserialization logic to detect and process `tree_` attributes using the new methods, ensuring correct round-trip conversion.

- **Backward Compatibility:**  
  The changes are designed to be backward compatible and do not affect the serialization of other estimator types.


---

## Impact

With these changes, users can now serialize and deserialize scikit-learn decision tree models and estimators that relies on the internal `Tree` structure, significantly expanding the range of supported models in OpenModels.

---

_Closes:_  
#22