### PR TITLE
Add Support for Ensemble Models and Nested Estimators

### DIFF
--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,6 +33,10 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
+        print("Serializing to JSON format")
+        print("Data to serialize:", data)
+        if not isinstance(data, dict):
+            raise TypeError("Data must be a dictionary.")
         return json.dumps(data)
 
     @staticmethod

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,8 +33,7 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
-        print("Serializing to JSON format")
-        print("Data to serialize:", data)
+     
         if not isinstance(data, dict):
             raise TypeError("Data must be a dictionary.")
         return json.dumps(data)

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -46,10 +46,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     #"BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
     "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
+    #"ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
     "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
-    "GradientBoostingClassifier",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "GradientBoostingClassifier",  # Object of type RandomState is not JSON serializable
     "HistGradientBoostingClassifier",  # Object of type TreePredictor is not JSON serializable
     "KNeighborsClassifier",  # Object of type KDTree is not JSON serializable
     "MLPClassifier",  # Object of type LabelBinarizer is not JSON serializable
@@ -60,9 +60,9 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "PassiveAggressiveClassifier",  # Object of type Hinge is not JSON serializable
     "Perceptron",  # Object of type Hinge is not JSON serializable
     "RadiusNeighborsClassifier",  # Object of type KDTree is not JSON serializable
-    "RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier",  # Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV",  # Object of type LabelBinarizer is not JSON serializable
+    #"RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
+    "RidgeClassifierCV",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "SGDClassifier",  # Object of type Hinge is not JSON serializable
     "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
     "StackingClassifier",  # StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
@@ -81,10 +81,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "GaussianRandomProjection",  # Object of type RandomState is not JSON serializable
     "GenericUnivariateSelect",  # Object of type function is not JSON serializable
     "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap",  # Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer",  # Object of type OneHotEncoder is not JSON serializable
+    "Isomap",  # Object of type KDTree is not JSON serializable
+    "KBinsDiscretizer",  # Object of type Float64DType is not JSON serializable
     "KNeighborsTransformer",  # Object of type KDTree is not JSON serializable
-    "KernelPCA",  # Object of type KernelCenterer is not JSON serializable
+    #"KernelPCA",  # Object of type KernelCenterer is not JSON serializable
     "LatentDirichletAllocation",  # Object of type RandomState is not JSON serializable
     "LinearDiscriminantAnalysis",  # This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
     "LocallyLinearEmbedding",  # Object of type NearestNeighbors is not JSON serializable"
@@ -95,11 +95,11 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "OneHotEncoder",  # Object of type type is not JSON serializable
     "OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer",  # Object of type StandardScaler is not JSON serializable
+    #"PowerTransformer",  # Object of type StandardScaler is not JSON serializable
     "RFE",  # RFE.__init__() missing 1 required positional argument: 'estimator'
     "RFECV",  # RFECV.__init__() missing 1 required positional argument: 'estimator'
     "RadiusNeighborsTransformer",  # Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "RandomTreesEmbedding",  # Object of type type is not JSON serializable
     "SelectFdr",  # Object of type function is not JSON serializable
     "SelectFpr",  # Object of type function is not JSON serializable
     "SelectFromModel",  # SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
@@ -119,9 +119,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
     "FrozenEstimator",  # FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
     "GridSearchCV",  # GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "IsolationForest",  # TypeError: only integer scalar arrays can be converted to a scalar index
     "KernelDensity",  # Object of type KDTree is not JSON serializable
     "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
+    "NearestNeighbors",  # Object of type KDTree is not JSON serializable
     "Pipeline",  # Pipeline.__init__() missing 1 required positional argument: 'steps'
     "RandomizedSearchCV",  # RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
     "SGDOneClassSVM",  # Object of type Hinge is not JSON serializable
@@ -192,7 +193,9 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "PolynomialFeatures": ["_max_degree", "_n_out_full", "_min_degree"],
     "PLSSVD": ["_x_mean", "_x_std"],
     # Others:
+    "IsolationForest":["_max_features", "_max_samples", "_decision_path_lengths", "_average_path_length_per_tree"],
     "OneClassSVM": ["_sparse", "_n_support", "_probA", "_probB", "_gamma"],
+    "NearestNeighbors":["_fit_method","_tree"]
 }
 
 
@@ -574,12 +577,6 @@ class SklearnSerializer(ModelSerializer):
         }
 
         attribute_types_map = dict(zip(filtered_attribute_keys, attribute_types))
-        # Debugging output to check the types and dtypes
-        print("params:", model.get_params())
-        print("Filtered attribute keys:", filtered_attribute_keys)
-        print("Attribute types:", attribute_types)
-        print("Attribute types map:", attribute_types_map)
-        print("Attribute dtypes map:", attribute_dtypes_map)
 
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
-from sklearn.tree import _tree
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
@@ -233,7 +232,7 @@ class SklearnSerializer(ModelSerializer):
         ]
 
     @staticmethod
-    def _serialize_tree(tree: _tree.Tree) -> Dict[str, Any]:
+    def _serialize_tree(tree: Tree) -> Dict[str, Any]:
         """
         Serializes a sklearn.tree._tree.Tree object to a dictionary.
 
@@ -256,7 +255,7 @@ class SklearnSerializer(ModelSerializer):
         }
 
     @staticmethod
-    def _deserialize_tree(tree_data: Dict[str, Any]) -> _tree.Tree:
+    def _deserialize_tree(tree_data: Dict[str, Any]) -> Tree:
         """
         Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
         """
@@ -298,7 +297,7 @@ class SklearnSerializer(ModelSerializer):
         Any
             The serializable representation of the value.
         """
-        if isinstance(value, (_tree.Tree)):
+        if isinstance(value, (Tree)):
             # If the value is a Tree object, serialize it to a dictionary
             return SklearnSerializer._serialize_tree(value)
 

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -592,7 +592,7 @@ class SklearnSerializer(ModelSerializer):
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
             # Handle tree_ separately
-            if attribute == "tree_":
+            if attr_type == "Tree":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
             else:
                 # Pass both value and attr_type to _convert_to_sklearn_types

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -13,7 +13,7 @@ from sklearn.tree import _tree
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.discovery import all_estimators 
+from sklearn.utils.discovery import all_estimators
 
 from openmodels.exceptions import UnsupportedEstimatorError, SerializationError
 from openmodels.protocols import ModelSerializer
@@ -246,14 +246,13 @@ class SklearnSerializer(ModelSerializer):
         state = tree.__getstate__()
 
         return {
-            'n_features': tree.n_features,
-            'n_outputs': tree.n_outputs,
-            'n_classes': tree.n_classes.tolist(),
-            'state': {
-                k: (v.tolist() if hasattr(v, 'tolist') else v)
-                for k, v in state.items()
+            "n_features": tree.n_features,
+            "n_outputs": tree.n_outputs,
+            "n_classes": tree.n_classes.tolist(),
+            "state": {
+                k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in state.items()
             },
-            'nodes_dtype': [list(t) for t in state['nodes'].dtype.descr],  # for JSON
+            "nodes_dtype": [list(t) for t in state["nodes"].dtype.descr],  # for JSON
         }
 
     @staticmethod
@@ -262,26 +261,28 @@ class SklearnSerializer(ModelSerializer):
         Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
         """
         tree = Tree(
-            tree_data['n_features'],
-            np.array(tree_data['n_classes'], dtype=np.intp),
-            tree_data['n_outputs']
+            tree_data["n_features"],
+            np.array(tree_data["n_classes"], dtype=np.intp),
+            tree_data["n_outputs"],
         )
 
         state = {}
-        for key, value in tree_data['state'].items():
-            if key == 'nodes':
+        for key, value in tree_data["state"].items():
+            if key == "nodes":
                 # Restore dtype
-                nodes_dtype_descr = [tuple(field) for field in tree_data['nodes_dtype'] if field[0] != '']
+                nodes_dtype_descr = [
+                    tuple(field) for field in tree_data["nodes_dtype"] if field[0] != ""
+                ]
                 nodes_dtype = np.dtype(nodes_dtype_descr)
                 if isinstance(value, list) and isinstance(value[0], list):
                     value = [tuple(row) for row in value]
-                state['nodes'] = np.array(value, dtype=nodes_dtype)
+                state["nodes"] = np.array(value, dtype=nodes_dtype)
             else:
                 state[key] = np.array(value)
 
         tree.__setstate__(state)
         return tree
-    
+
     @staticmethod
     def _convert_to_serializable_types(value: Any) -> Any:
         """
@@ -300,7 +301,7 @@ class SklearnSerializer(ModelSerializer):
         if isinstance(value, (_tree.Tree)):
             # If the value is a Tree object, serialize it to a dictionary
             return SklearnSerializer._serialize_tree(value)
-        
+
         if isinstance(value, dict):
             # Scikit-learn estimators (e.g., LogisticRegressionCV) may use non-string types
             # (such as np.int64 or float) as dictionary keys for attributes like `coefs_paths_`.
@@ -591,10 +592,10 @@ class SklearnSerializer(ModelSerializer):
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
             # Skip feature_importances_ if it's derived (can be recomputed)
-            if attribute == 'feature_importances_':
+            if attribute == "feature_importances_":
                 continue
             # Handle tree_ separately
-            if attribute == 'tree_':
+            if attribute == "tree_":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
                 continue
             else:

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,9 +9,11 @@ from typing import Any, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
+from sklearn.tree import _tree
+from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.discovery import all_estimators
+from sklearn.utils.discovery import all_estimators 
 
 from openmodels.exceptions import UnsupportedEstimatorError, SerializationError
 from openmodels.protocols import ModelSerializer
@@ -24,8 +26,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
     "AdaBoostRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
     "BaggingRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor",  # Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor",  # Object of type Tree is not JSON serializable
     "ExtraTreesRegressor",  # Object of type ExtraTreeRegressor is not JSON serializable
     "GammaRegressor",  # Object of type HalfGammaLoss is not JSON serializable
     "GaussianProcessRegressor",  # Object of type Product is not JSON serializable
@@ -39,7 +39,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "RegressorChain",  # _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
     "StackingRegressor",  # StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
     "TransformedTargetRegressor",  # Object of type LinearRegression is not JSON serializable
-    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
     "TweedieRegressor",  # Object of type HalfTweedieLossIdentity is not JSON serializable
     "VotingRegressor",  # VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
@@ -47,8 +46,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
     "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
-    "ExtraTreeClassifier",  # Object of type _Tree is not JSON serializable
     "ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
     "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
@@ -236,6 +233,56 @@ class SklearnSerializer(ModelSerializer):
         ]
 
     @staticmethod
+    def _serialize_tree(tree: _tree.Tree) -> Dict[str, Any]:
+        """
+        Serializes a sklearn.tree._tree.Tree object to a dictionary.
+
+        Parameters:
+            tree (sklearn.tree._tree.Tree): The internal tree structure from a fitted tree-based model (e.g., model.tree_)
+
+        Returns:
+            dict: Serialized tree attributes
+        """
+        state = tree.__getstate__()
+
+        return {
+            'n_features': tree.n_features,
+            'n_outputs': tree.n_outputs,
+            'n_classes': tree.n_classes.tolist(),
+            'state': {
+                k: (v.tolist() if hasattr(v, 'tolist') else v)
+                for k, v in state.items()
+            },
+            'nodes_dtype': [list(t) for t in state['nodes'].dtype.descr],  # for JSON
+        }
+
+    @staticmethod
+    def _deserialize_tree(tree_data: Dict[str, Any]) -> _tree.Tree:
+        """
+        Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
+        """
+        tree = Tree(
+            tree_data['n_features'],
+            np.array(tree_data['n_classes'], dtype=np.intp),
+            tree_data['n_outputs']
+        )
+
+        state = {}
+        for key, value in tree_data['state'].items():
+            if key == 'nodes':
+                # Restore dtype
+                nodes_dtype_descr = [tuple(field) for field in tree_data['nodes_dtype'] if field[0] != '']
+                nodes_dtype = np.dtype(nodes_dtype_descr)
+                if isinstance(value, list) and isinstance(value[0], list):
+                    value = [tuple(row) for row in value]
+                state['nodes'] = np.array(value, dtype=nodes_dtype)
+            else:
+                state[key] = np.array(value)
+
+        tree.__setstate__(state)
+        return tree
+    
+    @staticmethod
     def _convert_to_serializable_types(value: Any) -> Any:
         """
         Convert a value to a serializable type.
@@ -250,6 +297,10 @@ class SklearnSerializer(ModelSerializer):
         Any
             The serializable representation of the value.
         """
+        if isinstance(value, (_tree.Tree)):
+            # If the value is a Tree object, serialize it to a dictionary
+            return SklearnSerializer._serialize_tree(value)
+        
         if isinstance(value, dict):
             # Scikit-learn estimators (e.g., LogisticRegressionCV) may use non-string types
             # (such as np.int64 or float) as dictionary keys for attributes like `coefs_paths_`.
@@ -539,11 +590,19 @@ class SklearnSerializer(ModelSerializer):
             attr_type = data["attribute_types"].get(attribute)
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
-            # Pass both value and attr_type to _convert_to_sklearn_types
-            setattr(
-                model,
-                attribute,
-                self._convert_to_sklearn_types(value, attr_type, attr_dtype),
-            )
+            # Skip feature_importances_ if it's derived (can be recomputed)
+            if attribute == 'feature_importances_':
+                continue
+            # Handle tree_ separately
+            if attribute == 'tree_':
+                model.tree_ = SklearnSerializer._deserialize_tree(value)
+                continue
+            else:
+                # Pass both value and attr_type to _convert_to_sklearn_types
+                setattr(
+                    model,
+                    attribute,
+                    self._convert_to_sklearn_types(value, attr_type, attr_dtype),
+                )
 
         return model

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -591,13 +591,9 @@ class SklearnSerializer(ModelSerializer):
             attr_type = data["attribute_types"].get(attribute)
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
-            # Skip feature_importances_ if it's derived (can be recomputed)
-            if attribute == "feature_importances_":
-                continue
             # Handle tree_ separately
             if attribute == "tree_":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
-                continue
             else:
                 # Pass both value and attr_type to _convert_to_sklearn_types
                 setattr(


### PR DESCRIPTION
## Changes
This PR improves the serializer's handling of complex scikit-learn models, particularly focusing on ensemble models and their nested estimators. The main improvements are:

1. Added proper serialization of numpy arrays containing estimators
   - Special handling for object dtype arrays
   - Recursive serialization of nested estimators
   - Preservation of array structure

2. Enhanced dtype handling for arrays
   - Added automatic dtype detection for lists/tuples
   - Proper handling of integer arrays for indexing operations
   - Improved conversion between numpy and Python types

3. Fixed serialization of ensemble models:
   - AdaBoostRegressor
   - BaggingRegressor
   - Other tree-based ensemble models

## Technical Details
- Modified `_convert_to_serializable_types` to handle arrays of estimators
- Enhanced `get_dtype` to detect types from list elements
- Updated type conversion logic to preserve integer dtypes
- Removed several models from NOT_SUPPORTED_ESTIMATORS after fixes

## Testing
The following previously failing models now work:
- AdaBoostRegressor
- BaggingRegressor
- ExtraTreesRegressor
- RandomForestRegressor
- RANSACRegressor
- TransformedTargetRegresso
- AdaBoostClassifier
- BaggingClassifier
- ExtraTreesClassifier
- RandomForestClassifier
- KernelPCA
- PowerTransformer

_Closes:_  
#25 