### PR TITLE
Feat/add type tracking for model parameters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 200
 extend-ignore = E203, W503
-max-complexity = 10
+max-complexity = 14

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,6 +33,10 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
+        print("Serializing to JSON format")
+        print("Data to serialize:", data)
+        if not isinstance(data, dict):
+            raise TypeError("Data must be a dictionary.")
         return json.dumps(data)
 
     @staticmethod

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,8 +33,7 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
-        print("Serializing to JSON format")
-        print("Data to serialize:", data)
+     
         if not isinstance(data, dict):
             raise TypeError("Data must be a dictionary.")
         return json.dumps(data)

--- a/openmodels/converters/json_converter.py
+++ b/openmodels/converters/json_converter.py
@@ -33,7 +33,7 @@ class JSONConverter(FormatConverter):
         str
             The JSON string representation of the data.
         """
-     
+
         if not isinstance(data, dict):
             raise TypeError("Data must be a dictionary.")
         return json.dumps(data)

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -46,10 +46,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     #"BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
     "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
+    #"ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
     "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
-    "GradientBoostingClassifier",  # Object of type DecisionTreeRegressor is not JSON serializable
+    "GradientBoostingClassifier",  # Object of type RandomState is not JSON serializable
     "HistGradientBoostingClassifier",  # Object of type TreePredictor is not JSON serializable
     "KNeighborsClassifier",  # Object of type KDTree is not JSON serializable
     "MLPClassifier",  # Object of type LabelBinarizer is not JSON serializable
@@ -60,9 +60,9 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "PassiveAggressiveClassifier",  # Object of type Hinge is not JSON serializable
     "Perceptron",  # Object of type Hinge is not JSON serializable
     "RadiusNeighborsClassifier",  # Object of type KDTree is not JSON serializable
-    "RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier",  # Object of type LabelBinarizer is not JSON serializable
-    "RidgeClassifierCV",  # Object of type LabelBinarizer is not JSON serializable
+    #"RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
+    "RidgeClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
+    "RidgeClassifierCV",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "SGDClassifier",  # Object of type Hinge is not JSON serializable
     "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
     "StackingClassifier",  # StackingClassifier.__init__() missing 1 required positional argument: 'estimators'
@@ -81,10 +81,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "GaussianRandomProjection",  # Object of type RandomState is not JSON serializable
     "GenericUnivariateSelect",  # Object of type function is not JSON serializable
     "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "Isomap",  # Object of type KernelPCA is not JSON serializable
-    "KBinsDiscretizer",  # Object of type OneHotEncoder is not JSON serializable
+    "Isomap",  # Object of type KDTree is not JSON serializable
+    "KBinsDiscretizer",  # Object of type Float64DType is not JSON serializable
     "KNeighborsTransformer",  # Object of type KDTree is not JSON serializable
-    "KernelPCA",  # Object of type KernelCenterer is not JSON serializable
+    #"KernelPCA",  # Object of type KernelCenterer is not JSON serializable
     "LatentDirichletAllocation",  # Object of type RandomState is not JSON serializable
     "LinearDiscriminantAnalysis",  # This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
     "LocallyLinearEmbedding",  # Object of type NearestNeighbors is not JSON serializable"
@@ -95,11 +95,11 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "OneHotEncoder",  # Object of type type is not JSON serializable
     "OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "PowerTransformer",  # Object of type StandardScaler is not JSON serializable
+    #"PowerTransformer",  # Object of type StandardScaler is not JSON serializable
     "RFE",  # RFE.__init__() missing 1 required positional argument: 'estimator'
     "RFECV",  # RFECV.__init__() missing 1 required positional argument: 'estimator'
     "RadiusNeighborsTransformer",  # Object of type KDTree is not JSON serializable
-    "RandomTreesEmbedding",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "RandomTreesEmbedding",  # Object of type type is not JSON serializable
     "SelectFdr",  # Object of type function is not JSON serializable
     "SelectFpr",  # Object of type function is not JSON serializable
     "SelectFromModel",  # SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
@@ -119,9 +119,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
     "FrozenEstimator",  # FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
     "GridSearchCV",  # GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
-    "IsolationForest",  # Object of type ExtraTreeRegressor is not JSON serializable
+    "IsolationForest",  # TypeError: only integer scalar arrays can be converted to a scalar index
     "KernelDensity",  # Object of type KDTree is not JSON serializable
     "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
+    "NearestNeighbors",  # Object of type KDTree is not JSON serializable
     "Pipeline",  # Pipeline.__init__() missing 1 required positional argument: 'steps'
     "RandomizedSearchCV",  # RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
     "SGDOneClassSVM",  # Object of type Hinge is not JSON serializable
@@ -192,7 +193,9 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "PolynomialFeatures": ["_max_degree", "_n_out_full", "_min_degree"],
     "PLSSVD": ["_x_mean", "_x_std"],
     # Others:
+    "IsolationForest":["_max_features", "_max_samples", "_decision_path_lengths", "_average_path_length_per_tree"],
     "OneClassSVM": ["_sparse", "_n_support", "_probA", "_probB", "_gamma"],
+    "NearestNeighbors":["_fit_method","_tree"]
 }
 
 
@@ -574,12 +577,6 @@ class SklearnSerializer(ModelSerializer):
         }
 
         attribute_types_map = dict(zip(filtered_attribute_keys, attribute_types))
-        # Debugging output to check the types and dtypes
-        print("params:", model.get_params())
-        print("Filtered attribute keys:", filtered_attribute_keys)
-        print("Attribute types:", attribute_types)
-        print("Attribute types map:", attribute_types_map)
-        print("Attribute dtypes map:", attribute_dtypes_map)
 
         serializable_attribute_values = [
             self._convert_to_serializable_types(value) for value in attribute_values

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
-from sklearn.tree import _tree
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
@@ -233,7 +232,7 @@ class SklearnSerializer(ModelSerializer):
         ]
 
     @staticmethod
-    def _serialize_tree(tree: _tree.Tree) -> Dict[str, Any]:
+    def _serialize_tree(tree: Tree) -> Dict[str, Any]:
         """
         Serializes a sklearn.tree._tree.Tree object to a dictionary.
 
@@ -256,7 +255,7 @@ class SklearnSerializer(ModelSerializer):
         }
 
     @staticmethod
-    def _deserialize_tree(tree_data: Dict[str, Any]) -> _tree.Tree:
+    def _deserialize_tree(tree_data: Dict[str, Any]) -> Tree:
         """
         Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
         """
@@ -298,7 +297,7 @@ class SklearnSerializer(ModelSerializer):
         Any
             The serializable representation of the value.
         """
-        if isinstance(value, (_tree.Tree)):
+        if isinstance(value, (Tree)):
             # If the value is a Tree object, serialize it to a dictionary
             return SklearnSerializer._serialize_tree(value)
 

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,8 +9,8 @@ from typing import Any, Callable, Dict, List, Tuple, Type, Optional
 import numpy as np
 import inspect
 from scipy.sparse import _csr, csr_matrix  # type: ignore
-from scipy.stats._distn_infrastructure import rv_continuous_frozen
-import scipy.stats
+from scipy.stats._distn_infrastructure import rv_continuous_frozen # type: ignore
+import scipy.stats # type: ignore
 
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
@@ -689,7 +689,7 @@ class SklearnSerializer(ModelSerializer):
 
         # Get valid constructor arguments for the estimator
         estimator_cls = ALL_ESTIMATORS[estimator_class]
-        valid_args = inspect.signature(estimator_cls.__init__).parameters.keys()
+        valid_args = list(inspect.signature(estimator_cls.__init__).parameters.keys())
         # Remove 'self' if present
         valid_args = [arg for arg in valid_args if arg != 'self']
 

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -440,7 +440,7 @@ class SklearnSerializer(ModelSerializer):
             return estimator_class(**params)
     
         # Recursive case: if attr_type is a list, process each element in value
-        if isinstance(attr_type, List) and isinstance(value, List):
+        if isinstance(attr_type, list) and isinstance(value, list):
             return [
                 self._convert_to_sklearn_types(v, t, attr_dtype)
                 for v, t in zip(value, attr_type)
@@ -639,9 +639,7 @@ class SklearnSerializer(ModelSerializer):
 
         # Serialize model parameters
         params = model.get_params()
-        #print("params:", params)
         serializable_params = self._convert_to_serializable_types(params)
-        #print("serializable_params:", serializable_params)
         param_types = {param_name: SklearnSerializer.get_nested_types(param_value) for param_name, param_value in params.items()}
         param_dtypes = {
             param_name: SklearnSerializer.get_dtype(param_value)
@@ -729,7 +727,6 @@ class SklearnSerializer(ModelSerializer):
             else:
                 reconstructed_params[param_name] = self._convert_to_sklearn_types(param_value, param_type, param_dtype)
         model = estimator_cls(**reconstructed_params)
-        print("model type after instantiation:", type(model))
 
         
         for attribute, value in data["attributes"].items():
@@ -745,5 +742,5 @@ class SklearnSerializer(ModelSerializer):
                 attribute,
                 self._convert_to_sklearn_types(value, attr_type, attr_dtype),
             )
-        print("Reconstructed model:", model)
+            
         return model

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -592,7 +592,7 @@ class SklearnSerializer(ModelSerializer):
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
             # Handle tree_ separately
-            if attribute == "tree_":
+            if attr_type == "Tree":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
             else:
                 # Pass both value and attr_type to _convert_to_sklearn_types

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -206,6 +206,7 @@ class SklearnSerializer(ModelSerializer):
         A list of supported types for serialization.
     """
 
+    @staticmethod
     def all_estimators(
         type_filter: Optional[str] = None,
     ) -> List[Tuple[str, Type[BaseEstimator]]]:
@@ -316,7 +317,7 @@ class SklearnSerializer(ModelSerializer):
             "kwargs": value.kwds,
         }
 
-    def _convert_to_serializable_types(self, value: type) -> Dict[str, Any]:
+    def _convert_to_serializable_types(self, value: Any) -> Any:
         """
         Converts a value to a serializable type.
         """

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -5,7 +5,7 @@ This module provides a serializer for scikit-learn models, allowing them to be
 converted to and from dictionary representations.
 """
 
-from typing import Any, Dict, List, Tuple, Type, Optional
+from typing import Any, Callable, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
@@ -385,7 +385,7 @@ class SklearnSerializer(ModelSerializer):
                     ),
                     shape=tuple(value["shape"]),
                 )
-            type_map = {
+            type_map:Dict[str, Callable[[Any], Any]] = {
                 "int": int,
                 "int64": np.int64,
                 "int32": np.int32,

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -34,22 +34,15 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "GradientBoostingRegressor",  # Object of type RandomState is not JSON serializable
     "HistGradientBoostingRegressor",  # Object of type HalfSquaredError is not JSON serializable
     "IsotonicRegression",  # Object of type interp1d is not JSON serializable
-    #"MultiOutputRegressor",  # MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
     "PoissonRegressor",  # Object of type HalfPoissonLoss is not JSON serializable
-    #"RegressorChain",  # _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
-    #"StackingRegressor",  # StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
     "TweedieRegressor",  # Object of type HalfTweedieLossIdentity is not JSON serializable
-    #"VotingRegressor",  # VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
-    #"ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    #"FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
     "GradientBoostingClassifier",  # Object of type RandomState is not JSON serializable
     "HistGradientBoostingClassifier",  # Object of type TreePredictor is not JSON serializable
     "KNeighborsClassifier",  # Object of type KDTree is not JSON serializable
     "MLPClassifier",  # Object of type LabelBinarizer is not JSON serializable
-    #"MultiOutputClassifier",  # MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'
     "OneVsOneClassifier",  # AttributeError: 'dict' object has no attribute 'predict' 
     "OneVsRestClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "OutputCodeClassifier",  # AttributeError: 'dict' object has no attribute 'predict_proba'
@@ -59,7 +52,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "RidgeClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "RidgeClassifierCV",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "SGDClassifier",  # Object of type Hinge is not JSON serializable
-    #"AttributeError: 'dict' object has no attribute 'predict_proba'",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
     "StackingClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelEncoder
     "TunedThresholdClassifierCV",  # TypeError: Object of type _CurveScorer is not JSON serializable
     "VotingClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelEncoder
@@ -87,22 +79,16 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "MultiLabelBinarizer",  # MultiLabelBinarizer.fit() takes 2 positional arguments but 3 were given
     "NeighborhoodComponentsAnalysis",  # This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
     "OneHotEncoder",  # ValueError:
-    #"OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    #"RFE",  # RFE.__init__() missing 1 required positional argument: 'estimator'
-    #"RFECV",  # RFECV.__init__() missing 1 required positional argument: 'estimator'
     "RadiusNeighborsTransformer",  # Object of type KDTree is not JSON serializable
     "RandomTreesEmbedding",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: OneHotEncoder
     "SelectFdr",  # Object of type function is not JSON serializable
     "SelectFpr",  # Object of type function is not JSON serializable
-    #"SelectFromModel",  # SelectFromModel.__init__() missing 1 required positional argument: 'estimator'
     "SelectFwe",  # Object of type function is not JSON serializable
     "SelectKBest",  # Object of type function is not JSON serializable
     "SelectPercentile",  # Object of type function is not JSON serializable
-    #"SequentialFeatureSelector",  # SequentialFeatureSelector.__init__() missing 1 required positional argument: 'estimator'
     "SimpleImputer",  # Object of type Float64DType is not JSON serializable
     "SkewedChi2Sampler",  # ValueError: X may not contain entries smaller than -skewedness.
-    #"SparseCoder",  # SparseCoder.__init__() missing 1 required positional argument: 'dictionary'
     "SparseRandomProjection",  # ValueError: lead to a target dimension of 3353 which is larger than the original space with n_features=5
     "SplineTransformer",  # Object of type BSpline is not JSON serializable
     "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
@@ -110,14 +96,10 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Others:
     "BayesianGaussianMixture",  # Object of type ndarray is not JSON serializable
     "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
-    #"FrozenEstimator",  # FrozenEstimator.__init__() missing 1 required positional argument: 'estimator'
-    #"GridSearchCV",  # GridSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_grid'
     "IsolationForest",  # TypeError: only integer scalar arrays can be converted to a scalar index
     "KernelDensity",  # Object of type KDTree is not JSON serializable
     "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
     "NearestNeighbors",  # Object of type KDTree is not JSON serializable
-    #"Pipeline",  # Pipeline.__init__() missing 1 required positional argument: 'steps'
-    #"RandomizedSearchCV",  # RandomizedSearchCV.__init__() missing 2 required positional arguments: 'estimator' and 'param_distributions'
     "SGDOneClassSVM",  # Object of type Hinge is not JSON serializable
     "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
 ]
@@ -742,5 +724,5 @@ class SklearnSerializer(ModelSerializer):
                 attribute,
                 self._convert_to_sklearn_types(value, attr_type, attr_dtype),
             )
-            
+
         return model

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -13,7 +13,7 @@ from sklearn.tree import _tree
 from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.discovery import all_estimators 
+from sklearn.utils.discovery import all_estimators
 
 from openmodels.exceptions import UnsupportedEstimatorError, SerializationError
 from openmodels.protocols import ModelSerializer
@@ -246,14 +246,13 @@ class SklearnSerializer(ModelSerializer):
         state = tree.__getstate__()
 
         return {
-            'n_features': tree.n_features,
-            'n_outputs': tree.n_outputs,
-            'n_classes': tree.n_classes.tolist(),
-            'state': {
-                k: (v.tolist() if hasattr(v, 'tolist') else v)
-                for k, v in state.items()
+            "n_features": tree.n_features,
+            "n_outputs": tree.n_outputs,
+            "n_classes": tree.n_classes.tolist(),
+            "state": {
+                k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in state.items()
             },
-            'nodes_dtype': [list(t) for t in state['nodes'].dtype.descr],  # for JSON
+            "nodes_dtype": [list(t) for t in state["nodes"].dtype.descr],  # for JSON
         }
 
     @staticmethod
@@ -262,26 +261,28 @@ class SklearnSerializer(ModelSerializer):
         Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
         """
         tree = Tree(
-            tree_data['n_features'],
-            np.array(tree_data['n_classes'], dtype=np.intp),
-            tree_data['n_outputs']
+            tree_data["n_features"],
+            np.array(tree_data["n_classes"], dtype=np.intp),
+            tree_data["n_outputs"],
         )
 
         state = {}
-        for key, value in tree_data['state'].items():
-            if key == 'nodes':
+        for key, value in tree_data["state"].items():
+            if key == "nodes":
                 # Restore dtype
-                nodes_dtype_descr = [tuple(field) for field in tree_data['nodes_dtype'] if field[0] != '']
+                nodes_dtype_descr = [
+                    tuple(field) for field in tree_data["nodes_dtype"] if field[0] != ""
+                ]
                 nodes_dtype = np.dtype(nodes_dtype_descr)
                 if isinstance(value, list) and isinstance(value[0], list):
                     value = [tuple(row) for row in value]
-                state['nodes'] = np.array(value, dtype=nodes_dtype)
+                state["nodes"] = np.array(value, dtype=nodes_dtype)
             else:
                 state[key] = np.array(value)
 
         tree.__setstate__(state)
         return tree
-    
+
     @staticmethod
     def _convert_to_serializable_types(value: Any) -> Any:
         """
@@ -300,7 +301,7 @@ class SklearnSerializer(ModelSerializer):
         if isinstance(value, (_tree.Tree)):
             # If the value is a Tree object, serialize it to a dictionary
             return SklearnSerializer._serialize_tree(value)
-        
+
         if isinstance(value, dict):
             # Scikit-learn estimators (e.g., LogisticRegressionCV) may use non-string types
             # (such as np.int64 or float) as dictionary keys for attributes like `coefs_paths_`.
@@ -591,10 +592,10 @@ class SklearnSerializer(ModelSerializer):
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
             # Skip feature_importances_ if it's derived (can be recomputed)
-            if attribute == 'feature_importances_':
+            if attribute == "feature_importances_":
                 continue
             # Handle tree_ separately
-            if attribute == 'tree_':
+            if attribute == "tree_":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
                 continue
             else:

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -9,9 +9,11 @@ from typing import Any, Dict, List, Tuple, Type, Optional
 import numpy as np
 from scipy.sparse import _csr, csr_matrix  # type: ignore
 
+from sklearn.tree import _tree
+from sklearn.tree._tree import Tree
 from sklearn.base import BaseEstimator, check_is_fitted
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.discovery import all_estimators
+from sklearn.utils.discovery import all_estimators 
 
 from openmodels.exceptions import UnsupportedEstimatorError, SerializationError
 from openmodels.protocols import ModelSerializer
@@ -24,8 +26,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
     "AdaBoostRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
     "BaggingRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
-    "DecisionTreeRegressor",  # Object of type Tree is not JSON serializable
-    "ExtraTreeRegressor",  # Object of type Tree is not JSON serializable
     "ExtraTreesRegressor",  # Object of type ExtraTreeRegressor is not JSON serializable
     "GammaRegressor",  # Object of type HalfGammaLoss is not JSON serializable
     "GaussianProcessRegressor",  # Object of type Product is not JSON serializable
@@ -39,7 +39,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "RegressorChain",  # _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
     "StackingRegressor",  # StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
     "TransformedTargetRegressor",  # Object of type LinearRegression is not JSON serializable
-    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
     "TweedieRegressor",  # Object of type HalfTweedieLossIdentity is not JSON serializable
     "VotingRegressor",  # VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
@@ -47,8 +46,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
     "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    "DecisionTreeClassifier",  # Object of type _Tree is not JSON serializable
-    "ExtraTreeClassifier",  # Object of type _Tree is not JSON serializable
     "ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
     "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
@@ -236,6 +233,56 @@ class SklearnSerializer(ModelSerializer):
         ]
 
     @staticmethod
+    def _serialize_tree(tree: _tree.Tree) -> Dict[str, Any]:
+        """
+        Serializes a sklearn.tree._tree.Tree object to a dictionary.
+
+        Parameters:
+            tree (sklearn.tree._tree.Tree): The internal tree structure from a fitted tree-based model (e.g., model.tree_)
+
+        Returns:
+            dict: Serialized tree attributes
+        """
+        state = tree.__getstate__()
+
+        return {
+            'n_features': tree.n_features,
+            'n_outputs': tree.n_outputs,
+            'n_classes': tree.n_classes.tolist(),
+            'state': {
+                k: (v.tolist() if hasattr(v, 'tolist') else v)
+                for k, v in state.items()
+            },
+            'nodes_dtype': [list(t) for t in state['nodes'].dtype.descr],  # for JSON
+        }
+
+    @staticmethod
+    def _deserialize_tree(tree_data: Dict[str, Any]) -> _tree.Tree:
+        """
+        Deserializes a dictionary representation of a tree back to a sklearn.tree._tree.Tree object.
+        """
+        tree = Tree(
+            tree_data['n_features'],
+            np.array(tree_data['n_classes'], dtype=np.intp),
+            tree_data['n_outputs']
+        )
+
+        state = {}
+        for key, value in tree_data['state'].items():
+            if key == 'nodes':
+                # Restore dtype
+                nodes_dtype_descr = [tuple(field) for field in tree_data['nodes_dtype'] if field[0] != '']
+                nodes_dtype = np.dtype(nodes_dtype_descr)
+                if isinstance(value, list) and isinstance(value[0], list):
+                    value = [tuple(row) for row in value]
+                state['nodes'] = np.array(value, dtype=nodes_dtype)
+            else:
+                state[key] = np.array(value)
+
+        tree.__setstate__(state)
+        return tree
+    
+    @staticmethod
     def _convert_to_serializable_types(value: Any) -> Any:
         """
         Convert a value to a serializable type.
@@ -250,6 +297,10 @@ class SklearnSerializer(ModelSerializer):
         Any
             The serializable representation of the value.
         """
+        if isinstance(value, (_tree.Tree)):
+            # If the value is a Tree object, serialize it to a dictionary
+            return SklearnSerializer._serialize_tree(value)
+        
         if isinstance(value, dict):
             # Scikit-learn estimators (e.g., LogisticRegressionCV) may use non-string types
             # (such as np.int64 or float) as dictionary keys for attributes like `coefs_paths_`.
@@ -539,11 +590,19 @@ class SklearnSerializer(ModelSerializer):
             attr_type = data["attribute_types"].get(attribute)
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
-            # Pass both value and attr_type to _convert_to_sklearn_types
-            setattr(
-                model,
-                attribute,
-                self._convert_to_sklearn_types(value, attr_type, attr_dtype),
-            )
+            # Skip feature_importances_ if it's derived (can be recomputed)
+            if attribute == 'feature_importances_':
+                continue
+            # Handle tree_ separately
+            if attribute == 'tree_':
+                model.tree_ = SklearnSerializer._deserialize_tree(value)
+                continue
+            else:
+                # Pass both value and attr_type to _convert_to_sklearn_types
+                setattr(
+                    model,
+                    attribute,
+                    self._convert_to_sklearn_types(value, attr_type, attr_dtype),
+                )
 
         return model

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -23,9 +23,6 @@ ALL_ESTIMATORS = {
 
 NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors:
-    #"AdaBoostRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
-    #"BaggingRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
-    #"ExtraTreesRegressor",  # Object of type ExtraTreeRegressor is not JSON serializable
     "GammaRegressor",  # Object of type HalfGammaLoss is not JSON serializable
         # https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/_loss/loss.py
     "GaussianProcessRegressor",  # Object of type Product is not JSON serializable
@@ -34,19 +31,13 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "IsotonicRegression",  # Object of type interp1d is not JSON serializable
     "MultiOutputRegressor",  # MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'
     "PoissonRegressor",  # Object of type HalfPoissonLoss is not JSON serializable
-    #"RandomForestRegressor",  # Object of type DecisionTreeRegressor is not JSON serializable
-    #"RANSACRegressor",  # Object of type LinearRegression is not JSON serializable
     "RegressorChain",  # _BaseChain.__init__() missing 1 required positional argument: 'base_estimator'
     "StackingRegressor",  # StackingRegressor.__init__() missing 1 required positional argument: 'estimators'
-    #"TransformedTargetRegressor",  # Object of type LinearRegression is not JSON serializable
     "TweedieRegressor",  # Object of type HalfTweedieLossIdentity is not JSON serializable
     "VotingRegressor",  # VotingRegressor.__init__() missing 1 required positional argument: 'estimators'
     # Classifiers:
-    #"AdaBoostClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
-    #"BaggingClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
     "CalibratedClassifierCV",  # Object of type _CalibratedClassifier is not JSON serializable
     "ClassifierChain",  # ClassifierChain.__init__() missing 1 required positional argument: 'base_estimator'
-    #"ExtraTreesClassifier",  # Object of type ExtraTreeClassifier is not JSON serializable
     "FixedThresholdClassifier",  # FixedThresholdClassifier.__init__() missing 1 required positional argument: 'estimator'
     "GaussianProcessClassifier",  # Object of type OneVsRestClassifier is not JSON serializable
     "GradientBoostingClassifier",  # Object of type RandomState is not JSON serializable
@@ -60,8 +51,7 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "PassiveAggressiveClassifier",  # Object of type Hinge is not JSON serializable
     "Perceptron",  # Object of type Hinge is not JSON serializable
     "RadiusNeighborsClassifier",  # Object of type KDTree is not JSON serializable
-    #"RandomForestClassifier",  # Object of type DecisionTreeClassifier is not JSON serializable
-    "RidgeClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
+     "RidgeClassifier",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "RidgeClassifierCV",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: LabelBinarizer
     "SGDClassifier",  # Object of type Hinge is not JSON serializable
     "SelfTrainingClassifier",  # ValueError: You must pass an estimator to SelfTrainingClassifier. Use `estimator`.
@@ -84,7 +74,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "Isomap",  # Object of type KDTree is not JSON serializable
     "KBinsDiscretizer",  # Object of type Float64DType is not JSON serializable
     "KNeighborsTransformer",  # Object of type KDTree is not JSON serializable
-    #"KernelPCA",  # Object of type KernelCenterer is not JSON serializable
     "LatentDirichletAllocation",  # Object of type RandomState is not JSON serializable
     "LinearDiscriminantAnalysis",  # This LinearDiscriminantAnalysis estimator requires y to be passed, but the target y is None
     "LocallyLinearEmbedding",  # Object of type NearestNeighbors is not JSON serializable"
@@ -95,7 +84,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "OneHotEncoder",  # Object of type type is not JSON serializable
     "OrdinalEncoder",  # Object of type type is not JSON serializable
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    #"PowerTransformer",  # Object of type StandardScaler is not JSON serializable
     "RFE",  # RFE.__init__() missing 1 required positional argument: 'estimator'
     "RFECV",  # RFECV.__init__() missing 1 required positional argument: 'estimator'
     "RadiusNeighborsTransformer",  # Object of type KDTree is not JSON serializable

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -299,12 +299,8 @@ class SklearnSerializer(ModelSerializer):
         csr_value = csr_matrix(value)
         serialized_sparse_matrix = {
             "data": self._array_to_list(csr_value.data),
-            "indptr": self._array_to_list(
-                csr_value.indptr.astype(np.int32)
-            ),
-            "indices": self._array_to_list(
-                csr_value.indices.astype(np.int32)
-            ),
+            "indptr": self._array_to_list(csr_value.indptr.astype(np.int32)),
+            "indices": self._array_to_list(csr_value.indices.astype(np.int32)),
             "shape": self._array_to_list(csr_value.shape),
         }
         return serialized_sparse_matrix
@@ -619,9 +615,7 @@ class SklearnSerializer(ModelSerializer):
 
         # Generate attribute types with nested structure.
         # These types are used to convert the serialized attributes back to their original types.
-        attribute_types = [
-            self.get_nested_types(value) for value in attribute_values
-        ]
+        attribute_types = [self.get_nested_types(value) for value in attribute_values]
 
         attribute_dtypes_map = {
             key: self.get_dtype(value)

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -591,13 +591,9 @@ class SklearnSerializer(ModelSerializer):
             attr_type = data["attribute_types"].get(attribute)
             # Get dtype if available
             attr_dtype = data.get("attribute_dtypes", {}).get(attribute)
-            # Skip feature_importances_ if it's derived (can be recomputed)
-            if attribute == "feature_importances_":
-                continue
             # Handle tree_ separately
             if attribute == "tree_":
                 model.tree_ = SklearnSerializer._deserialize_tree(value)
-                continue
             else:
                 # Pass both value and attr_type to _convert_to_sklearn_types
                 setattr(

--- a/test/test_others.py
+++ b/test/test_others.py
@@ -48,8 +48,41 @@ def data():
 @pytest.mark.parametrize("Others", OTHERS)
 def test_others(Others, data):
     x, y = data
-    others = Others()
-    
+
+    args = {}
+    if Others.__name__ == "FrozenEstimator":
+        from sklearn.linear_model import LogisticRegression
+        base_estimator = LogisticRegression()
+        base_estimator.fit(x, y)
+        args["estimator"] = base_estimator
+    if Others.__name__ == "GridSearchCV":
+        from sklearn.linear_model import LogisticRegression
+        # Define a simple parameter grid
+        param_grid = {"C": [0.1, 1.0]}
+        # Use a simple base estimator
+        base_estimator = LogisticRegression()
+        args["estimator"] = base_estimator
+        args["param_grid"] = param_grid
+    if Others.__name__ == "Pipeline":
+        from sklearn.preprocessing import StandardScaler
+        from sklearn.linear_model import LogisticRegression
+        # Example pipeline: scaler + classifier
+        args["steps"] = [
+            ("scaler", StandardScaler()),
+            ("clf", LogisticRegression())  # The last step must be a predictor!
+    ]
+    if Others.__name__ == "RandomizedSearchCV":
+        from sklearn.linear_model import LogisticRegression
+        from scipy.stats import uniform
+        # Define a simple parameter distribution
+        param_distributions = {"C": uniform(0.1, 1.0)}
+        # Use a simple base estimator
+        base_estimator = LogisticRegression()
+        args["estimator"] = base_estimator
+        args["param_distributions"] = param_distributions
+
+    others = Others(**args)
+
     # Run the test model
     run_test_model(others, x, y, None, None, f"{Others.__name__.lower()}.json")
  

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,12 +1,10 @@
 import pytest
 import random
 import numpy as np
-from sklearn.svm import LinearSVR
 from sklearn.utils.discovery import all_estimators
 from sklearn.datasets import make_regression
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.linear_model import LinearRegression
-from sklearn.svm import LinearSVR
 from sklearn.ensemble import RandomForestRegressor
 from openmodels.test_helpers import run_test_model
 from openmodels.serializers.sklearn_serializer import NOT_SUPPORTED_ESTIMATORS
@@ -18,7 +16,7 @@ REGRESSORS = [cls for name, cls in all_estimators(type_filter="regressor")
 @pytest.fixture(scope="module")
 def data():
     x, y = make_regression(  # type: ignore
-        n_samples=50,
+        n_samples=100,
         n_features=3,
         n_informative=3,
         random_state=42,

--- a/test/test_transformation.py
+++ b/test/test_transformation.py
@@ -6,11 +6,15 @@ from sklearn.datasets import make_classification
 from sklearn.feature_extraction import FeatureHasher
 from openmodels.test_helpers import run_test_model
 from openmodels.serializers.sklearn_serializer import NOT_SUPPORTED_ESTIMATORS
+from test.test_regression import REGRESSORS
+from test.test_classification import CLASSIFIERS
 
-# Get all transformer estimators, filtering out not supported ones
+# Get all transformer estimators, filtering out not supported ones and those that are also regressors/classifiers
 TRANSFORMERS = [
     cls for name, cls in all_estimators(type_filter="transformer")
     if name not in NOT_SUPPORTED_ESTIMATORS
+    and name not in [reg.__name__ for reg in REGRESSORS]
+    and name not in [clf.__name__ for clf in CLASSIFIERS]
 ]
 
 @pytest.fixture(scope="module")
@@ -68,6 +72,7 @@ def test_transformer(Transformer, data):
         x = pairwise_kernels(X, metric="linear")
     if Transformer.__name__ in ["PLSSVD"]:
         args["n_components"] = 1
+
 
     transformer = Transformer(**args)
 

--- a/test/test_transformation.py
+++ b/test/test_transformation.py
@@ -50,8 +50,6 @@ def test_transformer(Transformer, data):
     if Transformer.__name__ in ["AdditiveChi2Sampler", "MiniBatchNMF", "LatentDirichletAllocation", "NMF"]:
         x = np.abs(x)
     
-    if Transformer.__name__ not in ["CCA", "GenericUnivariateSelect", "PLSCanonical", "PLSRegression", "PLSSVD", "SelectFdr", "SelectFpr", "SelectFwe", "SelectKBest", "SelectPercentile"]:
-        y = None
     if Transformer.__name__ in ["CCA", "PLSCanonical"]:
         args["n_components"] = 1
     if Transformer.__name__ in ["FeatureHasher"]:
@@ -72,6 +70,47 @@ def test_transformer(Transformer, data):
         x = pairwise_kernels(X, metric="linear")
     if Transformer.__name__ in ["PLSSVD"]:
         args["n_components"] = 1
+    if Transformer.__name__ == "ColumnTransformer":
+        from sklearn.preprocessing import StandardScaler, OneHotEncoder
+        # Example input: 2 numeric columns, 1 categorical column
+        x = np.array([
+            [0.5, 1.0, 'A'],
+            [1.5, 2.0, 'B'],
+            [3.0, 3.5, 'A'],
+            [2.5, 2.0, 'C']
+        ], dtype=object)
+        y = None
+        x_sparse = None
+        args["transformers"] = [
+            ("num", StandardScaler(), [0, 1]),
+            ("cat", OneHotEncoder(), [2])
+    ]
+    if Transformer.__name__ == "FeatureUnion":
+        from sklearn.preprocessing import StandardScaler, MinMaxScaler
+        # Example input: numeric data
+        x = np.array([
+            [0.5, 1.0],
+            [1.5, 2.0],
+            [3.0, 3.5],
+            [2.5, 2.0]
+        ])
+        y = None
+        x_sparse = None
+        args["transformer_list"] = [
+            ("scaler1", StandardScaler()),
+            ("scaler2", MinMaxScaler())
+        ]
+    if Transformer.__name__ in ["SelectFromModel", "SequentialFeatureSelector", "RFE", "RFECV"]:
+        from sklearn.linear_model import LogisticRegression
+        args["estimator"] = LogisticRegression()
+    if Transformer.__name__ == "SparseCoder":
+        # SparseCoder requires a dictionary (components) for initialization
+        # Let's create a random dictionary with shape (n_components, n_features)
+        n_components = 5
+        n_features = x.shape[1] if x is not None else 5
+        rng = np.random.RandomState(42)
+        dictionary = rng.rand(n_components, n_features)
+        args["dictionary"] = dictionary
 
 
     transformer = Transformer(**args)


### PR DESCRIPTION
Requires #28 

### **Changes**

- Centralized recursive logic for reconstructing both fitted and unfitted estimators in `_convert_to_sklearn_types`.
- Added support for serializing and deserializing `scipy` frozen distributions (`rv_continuous_frozen`) for meta-estimators like `RandomizedSearchCV`.
- Improved handling of slices and Python type objects in serialization/deserialization.
- Ensured pipeline steps and other meta-estimator parameters are properly deserialized as estimator objects, not dicts.
- Simplified attribute and parameter reconstruction using unified conversion logic.
- Special-cased pipeline steps in deserialization to ensure each step is an actual estimator.
- Cleaned up and unified handling for nested estimators in both parameters and attributes.

---

### **Technical Details**

- `_convert_to_serializable_types` now detects and serializes `rv_continuous_frozen`, `slice`, and Python `type` objects.
- `_convert_to_sklearn_types` now recursively deserializes any dict with `"estimator_class"` (fitted estimator) or `"__template__"` (unfitted estimator).
- Pipeline steps are handled by recursively deserializing each estimator in the steps list.
- All estimator parameters and attributes are processed through `_convert_to_sklearn_types`, ensuring robust reconstruction for complex meta-estimators and nested structures.
- The deserialization logic now supports meta-estimators and transformers that previously failed due to improper handling of nested estimators or special types.

---

### **Testing**

**The following previously failing models now work:**

- `MultiOutputRegressor`
- `RegressorChain`
- `StackingRegressor`
- `VotingRegressor`
- `ClassifierChain`
- `FixedThresholdClassifier`
- `MultiOutputClassifier`
- `SelfTrainingClassifier`
- `OrdinalEncoder`
- `RFE`
- `RFECV`
- `SelectFromModel`
- `SequentialFeatureSelector`
- `SparseCoder`
- `FrozenEstimator`
- `GridSearchCV`
- `Pipeline`
- `RandomizedSearchCV`

All these models were previously commented out in `NOT_SUPPORTED_ESTIMATORS` due to serialization or deserialization errors.  
With these changes, they now serialize and deserialize correctly, and their `.predict`/`.transform` methods work as expected in tests.

Closes:
https://github.com/SF-Tec/openmodels/issues/29