### PR TITLE
 Refactor scikit-learn serialization using mixin-based architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,6 @@ Follow OpenModels coding style:
 - Format code using [Black](https://black.readthedocs.io/en/stable/)
 
 Before submitting your changes, please ensure your code passes formatting, linting, and type checks by running:
-run black openmodels
-run flake8 openmodels
-run mypy openmodels
-
 ## Codecov
 
 Ensure your changes don't reduce OpenModels's test coverage. We use Codecov to track coverage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,13 @@ Follow OpenModels coding style:
 - Format code using [Black](https://black.readthedocs.io/en/stable/)
 
 Before submitting your changes, please ensure your code passes formatting, linting, and type checks by running:
+
+```bash
+poetry run black openmodels
+poetry run flake8 openmodels
+poetry run mypy openmodels  
+
+```
 ## Codecov
 
 Ensure your changes don't reduce OpenModels's test coverage. We use Codecov to track coverage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ Follow OpenModels coding style:
 - Avoid magic numbers or hard-coded strings
 - Format code using [Black](https://black.readthedocs.io/en/stable/)
 
+Before submitting your changes, please ensure your code passes formatting, linting, and type checks by running:
+run black openmodels
+run flake8 openmodels
+run mypy openmodels
+
 ## Codecov
 
 Ensure your changes don't reduce OpenModels's test coverage. We use Codecov to track coverage.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/openmodels.svg)](https://badge.fury.io/py/openmodels)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python Versions](https://img.shields.io/pypi/pyversions/openmodels.svg)](https://pypi.org/project/openmodels/)
-[![TestPyPI version](https://img.shields.io/pypi/v/openmodels?label=TestPyPI&color=blue&server=https://test.pypi.org/pypi)](https://test.pypi.org/project/openmodels/)
+[![TestPyPI version](https://img.shields.io/badge/TestPyPI-0.1.0a6-orange)](https://test.pypi.org/project/openmodels/)
 
 OpenModels is a flexible and extensible library for serializing and deserializing machine learning models. It's designed to support any serialization format through a plugin-based architecture, providing a safe and transparent solution for exporting and sharing predictive models.
 

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -52,7 +52,7 @@ class SerializerMixin:
         if isinstance(value_type, str):
             for typ_name, handler in self._get_deserializer_handlers():
                 if typ_name == value_type:
-                    if value_type in ("ndarray"):
+                    if value_type == "ndarray":
                         return handler(value, value_dtype)
                     return handler(value)
 

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -18,8 +18,8 @@ from typing import Any, Optional
 
 class SerializerMixin:
     """
-    Base mixin providing recursive serialization and, native python objects
-    serialization a dispatch mechanism. Other mixins only need to implement
+    Base mixin providing recursive serialization and native Python object
+    serialization with a dispatch mechanism. Other mixins only need to implement
     `_get_handlers()` and serialization helpers.
     """
 

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -74,8 +74,17 @@ class SerializerMixin:
 
     def _deserialize_type(self, value):
         # Deserialize Python type objects from their string name
-        # Default to float if not found
-        return getattr(__builtins__, value["type_name"], float)
+        # Only allow a safe whitelist of types; default to float if not found
+        allowed_types = {
+            "int": int,
+            "float": float,
+            "str": str,
+            "bool": bool,
+            "tuple": tuple,
+            "list": list,
+            "dict": dict,
+        }
+        return allowed_types.get(value["type_name"], float)
 
     # --- Handlers ---
     def _get_serializer_handlers(self):

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -40,11 +40,8 @@ class SerializerMixin:
         return value
 
     def convert_from_serializable(
-            self,
-            value: Any,
-            value_type: Any = "none",
-            value_dtype: Optional[str] = None
-        ) -> Any:
+        self, value: Any, value_type: Any = "none", value_dtype: Optional[str] = None
+    ) -> Any:
 
         if isinstance(value_type, list) and isinstance(value, list):
             return [
@@ -58,13 +55,12 @@ class SerializerMixin:
                     if value_type in ("ndarray"):
                         return handler(value, value_dtype)
                     return handler(value)
-                
 
         return value
-    
+
     def _serialize_slice(self, value: slice):
         return {"start": value.start, "stop": value.stop, "step": value.step}
-    
+
     def _deserialize_slice(self, value):
         return slice(
             start=value.get("start"),
@@ -74,11 +70,11 @@ class SerializerMixin:
 
     def _serialize_type(self, value: type):
         return {"type_name": value.__name__}
-    
+
     def _deserialize_type(self, value):
         # Deserialize Python type objects from their string name
         # Default to float if not found
-        return getattr(__builtins__, value["type_name"], float) 
+        return getattr(__builtins__, value["type_name"], float)
 
     def _get_serializer_handlers(self):
         """Each mixin extends this list."""
@@ -86,7 +82,7 @@ class SerializerMixin:
             (slice, self._serialize_slice),
             (type, self._serialize_type),
         ]
-    
+
     def _get_deserializer_handlers(self):
         return [
             ("bool", bool),
@@ -132,15 +128,15 @@ class NumpySerializerMixin(SerializerMixin):
                 lambda v: [self.convert_to_serializable(x) for x in v.get_state()],
             ),
         ]
-    
+
     def _get_deserializer_handlers(self):
         return super()._get_deserializer_handlers() + [
             ("ndarray", lambda v, dt=None: np.array(v, dtype=(dt or None))),
             ("generic", lambda v: np.array(v).item()),
             ("float64", np.float64),
-            ("int32",  int),
-            ("int64",  int),
-            ("dtype",  np.dtype),
+            ("int32", int),
+            ("int64", int),
+            ("dtype", np.dtype),
             ("Float64DType", np.dtype),
             ("RandomState", np.random.RandomState),
         ]
@@ -155,7 +151,7 @@ class ScipySerializerMixin(SerializerMixin):
             "indices": self.convert_to_serializable(csr_value.indices.astype(np.int32)),
             "shape": self.convert_to_serializable(csr_value.shape),
         }
-    
+
     def _deserialize_crs_matrix(self, value, value_dtype=None):
         return csr_matrix(
             (
@@ -163,7 +159,7 @@ class ScipySerializerMixin(SerializerMixin):
                 np.array(value["indices"], dtype=np.int32),
                 np.array(value["indptr"], dtype=np.int32),
             ),
-            shape=tuple(value["shape"])
+            shape=tuple(value["shape"]),
         )
 
     def _serialize_interp1d(self, value: interp1d):
@@ -180,18 +176,18 @@ class ScipySerializerMixin(SerializerMixin):
             "axis": getattr(value, "axis", -1),
             "copy": getattr(value, "copy", True),
         }
-    
+
     def _deserialize_interp1d(self, value, value_dtype=None):
         return interp1d(
-                    x=value["x"],
-                    y=value["y"],
-                    kind=value["kind"],
-                    fill_value=value["fill_value"],
-                    bounds_error=value["bounds_error"],
-                    assume_sorted=value["assume_sorted"],
-                    axis=value["axis"],
-                    copy=value["copy"],
-                )
+            x=value["x"],
+            y=value["y"],
+            kind=value["kind"],
+            fill_value=value["fill_value"],
+            bounds_error=value["bounds_error"],
+            assume_sorted=value["assume_sorted"],
+            axis=value["axis"],
+            copy=value["copy"],
+        )
 
     def _serialize_scipy_dist(self, value: rv_continuous_frozen):
         return {"dist_name": value.dist.name, "args": value.args, "kwargs": value.kwds}
@@ -206,12 +202,10 @@ class ScipySerializerMixin(SerializerMixin):
             (interp1d, self._serialize_interp1d),
             (rv_continuous_frozen, self._serialize_scipy_dist),
         ]
-    
+
     def _get_deserializer_handlers(self):
         return super()._get_deserializer_handlers() + [
             ("csr_matrix", self._deserialize_crs_matrix),
             ("interp1d", self._deserialize_interp1d),
-            ("scipy_dist", self._deserialize_scipy_dist)
+            ("scipy_dist", self._deserialize_scipy_dist),
         ]
-
-    

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -1,0 +1,115 @@
+# base.py
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.interpolate import interp1d
+from scipy.stats._distn_infrastructure import rv_continuous_frozen
+
+from typing import Any
+
+
+class SerializerMixin:
+    """
+    Base mixin providing recursive serialization and, native python objects 
+    serialization a dispatch mechanism. Other mixins only need to implement
+    `_get_handlers()` and serialization helpers.
+    """
+
+    def convert_to_serializable(self, value):
+        """Recursively convert values into JSON-serializable types."""
+        # First check custom handlers
+        for typ, handler in self._get_handlers():
+            if isinstance(value, typ):
+                return handler(value)
+
+        # Recursive case: dict, list, tuple
+        if isinstance(value, dict):
+            return {str(k): self.convert_to_serializable(v) for k, v in value.items()}
+
+        if isinstance(value, (list, tuple)):
+            return [self.convert_to_serializable(v) for v in value]
+
+        return value
+    
+    def _serialize_slice(self, value: slice):
+        return {"start": value.start, "stop": value.stop, "step": value.step}
+
+    def _serialize_type(self, value: type):
+        return {"type_name": value.__name__}
+
+    def _get_handlers(self):
+        """Each mixin extends this list."""
+        return [
+            (slice, self._serialize_slice),
+            (type, self._serialize_type),
+        ]
+
+
+class NumpySerializerMixin(SerializerMixin):
+    def _get_dtype(self, value: Any) -> str:
+        """
+        Get the dtype of a numpy array, otherwise return empty string.
+        """
+        if isinstance(value, np.ndarray):
+            return str(value.dtype)  # Get the actual numpy dtype
+        elif isinstance(value, (list, tuple)) and value:
+            # If it's a list/tuple that will become an ndarray, check its elements
+            first_elem = value[0]
+            if isinstance(first_elem, (int, np.integer)):
+                return "int32"  # Use int32 for integer lists
+            elif isinstance(first_elem, (float, np.floating)):
+                return "float64"  # Use float64 for float lists
+        return ""
+      
+    def _serialize_ndarray(self, value: np.ndarray):
+        return self.convert_to_serializable(value.tolist())
+
+    def _serialize_generic(self, value: np.generic):
+        return value.item()
+
+    def _get_handlers(self):
+        return super()._get_handlers() + [
+            (np.ndarray, self._serialize_ndarray),
+            (np.generic, self._serialize_generic),
+            (np.dtype, str),
+            (type(np.dtype("float64")), str),
+            (
+                np.random.RandomState,
+                lambda v: [self.convert_to_serializable(x) for x in v.get_state()],
+            ),
+        ]
+
+
+class ScipySerializerMixin(SerializerMixin):
+    def _serialize_csr_matrix(self, value: csr_matrix):
+        csr_value = csr_matrix(value)
+        return {
+            "data": self.convert_to_serializable(csr_value.data),
+            "indptr": self.convert_to_serializable(csr_value.indptr.astype(np.int32)),
+            "indices": self.convert_to_serializable(csr_value.indices.astype(np.int32)),
+            "shape": self.convert_to_serializable(csr_value.shape),
+        }
+
+    def _serialize_interp1d(self, value: interp1d):
+        fill_value = getattr(value, "fill_value", np.nan)
+        if isinstance(fill_value, np.ndarray):
+            fill_value = self.convert_to_serializable(fill_value)
+        return {
+            "x": self.convert_to_serializable(value.x),
+            "y": self.convert_to_serializable(value.y),
+            "kind": getattr(value, "_kind", "linear"),
+            "fill_value": fill_value,
+            "bounds_error": getattr(value, "bounds_error", None),
+            "assume_sorted": getattr(value, "assume_sorted", False),
+            "axis": getattr(value, "axis", -1),
+            "copy": getattr(value, "copy", True),
+        }
+
+    def _serialize_scipy_dist(self, value: rv_continuous_frozen):
+        return {"dist_name": value.dist.name, "args": value.args, "kwargs": value.kwds}
+
+    def _get_handlers(self):
+        return super()._get_handlers() + [
+            (csr_matrix, self._serialize_csr_matrix),
+            (interp1d, self._serialize_interp1d),
+            (rv_continuous_frozen, self._serialize_scipy_dist),
+        ]

--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -1,15 +1,23 @@
-# base.py
+"""
+Mixins for extensible serialization of Python, NumPy, and SciPy objects.
+
+This module provides a flexible mixin-based architecture for converting complex objects
+(such as slices, types, NumPy arrays, and SciPy structures) into JSON-serializable formats.
+Each mixin implements handlers for specific types, allowing easy extension and modular
+support for new serialization targets.
+"""
+
 import numpy as np
-from scipy.sparse import csr_matrix
-from scipy.interpolate import interp1d
-from scipy.stats._distn_infrastructure import rv_continuous_frozen
+from scipy.sparse import csr_matrix  # type: ignore
+from scipy.interpolate import interp1d  # type: ignore
+from scipy.stats._distn_infrastructure import rv_continuous_frozen  # type: ignore
 
 from typing import Any
 
 
 class SerializerMixin:
     """
-    Base mixin providing recursive serialization and, native python objects 
+    Base mixin providing recursive serialization and, native python objects
     serialization a dispatch mechanism. Other mixins only need to implement
     `_get_handlers()` and serialization helpers.
     """
@@ -29,7 +37,7 @@ class SerializerMixin:
             return [self.convert_to_serializable(v) for v in value]
 
         return value
-    
+
     def _serialize_slice(self, value: slice):
         return {"start": value.start, "stop": value.stop, "step": value.step}
 
@@ -59,7 +67,7 @@ class NumpySerializerMixin(SerializerMixin):
             elif isinstance(first_elem, (float, np.floating)):
                 return "float64"  # Use float64 for float lists
         return ""
-      
+
     def _serialize_ndarray(self, value: np.ndarray):
         return self.convert_to_serializable(value.tolist())
 

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -372,8 +372,7 @@ class SklearnSerializer(
         ]
         # Estimators
         estimator_handlers = [
-            (est_name, self.deserialize)
-            for est_name in ALL_ESTIMATORS.keys()
+            (est_name, self.deserialize) for est_name in ALL_ESTIMATORS.keys()
         ]
         return loss_handlers + estimator_handlers + super()._get_deserializer_handlers()
 

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -372,7 +372,7 @@ class SklearnSerializer(
         ]
         # Estimators
         estimator_handlers = [
-            (est_name, (lambda v: self.deserialize(v)))
+            (est_name, self.deserialize)
             for est_name in ALL_ESTIMATORS.keys()
         ]
         return loss_handlers + estimator_handlers + super()._get_deserializer_handlers()

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -8,12 +8,8 @@ converted to and from dictionary representations.
 from typing import Any, Callable, Dict, List, Tuple, Type, Optional
 import numpy as np
 import inspect
-from scipy.interpolate import interp1d  # type: ignore
-from scipy.sparse import csr_matrix  # type: ignore
-import scipy.stats  # type: ignore
 
 import sklearn
-
 from sklearn._loss.loss import (
     AbsoluteError,
     HalfBinomialLoss,
@@ -295,7 +291,7 @@ class SklearnSerializer(
             (BaseLoss, self._serialize_loss),
             (np.ndarray, self._serialize_estimators_ndarray),
         ] + super()._get_serializer_handlers()
-    
+
     def _get_deserializer_handlers(self):
         # Register losses
         loss_handlers = [
@@ -304,17 +300,10 @@ class SklearnSerializer(
         ]
         # Estimators
         estimator_handlers = [
-            (
-                est_name,
-                (lambda v: self.deserialize(v))
-            )
+            (est_name, (lambda v: self.deserialize(v)))
             for est_name in ALL_ESTIMATORS.keys()
         ]
-        return (
-            loss_handlers 
-            + estimator_handlers
-            + super()._get_deserializer_handlers()
-        )
+        return loss_handlers + estimator_handlers + super()._get_deserializer_handlers()
 
     def _serialize_tree(self, tree: Tree) -> Dict[str, Any]:
         """
@@ -385,9 +374,9 @@ class SklearnSerializer(
         # Fix for TweedieRegressor: ensure 'power' is not None
         if "power" in params and params["power"] is None:
             params["power"] = getattr(value, "power", 0.0)
-        return {"params": params}  
+        return {"params": params}
 
-    def _deserialize_loss(self, value: Dict[str, Any], loss_name:str) -> BaseLoss:
+    def _deserialize_loss(self, value: Dict[str, Any], loss_name: str) -> BaseLoss:
         loss_cls = LOSS_CLASS_REGISTRY[loss_name]
         params = value.get("params", {})
         return loss_cls(**params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openmodels"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 description = "Export scikit-learn model files to JSON for sharing or deploying predictive models with peace of mind."
 authors = [
     "Alejandro Gutierrez <agutierrez@sftec.es>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>, Ruben Parrilla <rparrilla@sftec.es>",


### PR DESCRIPTION
## PR: Add mixin-based serialization architecture for scikit-learn models

### Overview

This PR introduces a mixin-based approach for serializing and deserializing scikit-learn models in the OpenModels library. The new design separates generic serialization logic (for Python, NumPy, and SciPy objects) into dedicated mixins, while scikit-learn-specific logic remains in `SklearnSerializer`.

### Key Changes

- Added `SerializerMixin`, `NumpySerializerMixin`, and `ScipySerializerMixin` for extensible, recursive serialization and deserialization of core Python, NumPy, and SciPy types.
- Refactored `SklearnSerializer` to use these mixins, keeping estimator-specific logic isolated.
- Improved handling of nested estimators, numpy arrays, and custom types.
- Enhanced maintainability and extensibility for future serialization targets.
- Ensured backward compatibility for existing workflows.

### Motivation

This modular architecture makes it easier to extend serialization support for new types and libraries, reduces code duplication, and clarifies the responsibilities of each component.

### Impact

- No breaking changes.
- Serialization and deserialization are now more robust and easier to maintain.
- New types can be supported by adding mixins without modifying core logic.

---
*closes* #24 
