### PR TITLE
Fix dtype-robust sparse matrix comparison in tests; enable DictVectorizer, KNeighborsTransformer, OneHotEncoder, RadiusNeighborsTransformer, and special handling for text vectorizers

### DIFF
--- a/openmodels/serializers/base.py
+++ b/openmodels/serializers/base.py
@@ -170,12 +170,14 @@ class ScipySerializerMixin(SerializerMixin):
             "indptr": self.convert_to_serializable(csr_value.indptr.astype(np.int32)),
             "indices": self.convert_to_serializable(csr_value.indices.astype(np.int32)),
             "shape": self.convert_to_serializable(csr_value.shape),
+            "dtype": str(csr_value.data.dtype),
         }
 
     def _deserialize_csr_matrix(self, value, value_dtype=None):
+        dtype = value.get("dtype", None) or value_dtype or np.float64
         return csr_matrix(
             (
-                np.array(value["data"], dtype=value_dtype or np.float64),
+                np.array(value["data"], dtype=dtype),
                 np.array(value["indices"], dtype=np.int32),
                 np.array(value["indptr"], dtype=np.int32),
             ),

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -760,12 +760,9 @@ class SklearnSerializer(
         >>> serializer = SklearnSerializer()
         >>> serialized_dict = serializer.serialize(model)
         """
-        print("Serializing model of type:", model.__class__.__name__)
         # Extract and build estimator params and its types/dtypes map
         params = model.get_params(deep=False)
         param_types, param_dtypes = self._get_type_maps(params)
-        print("param_types:", param_types)
-        print("param_dtypes:", param_dtypes)
 
         # Build serializable estimator including extra info
         serialized_estimator = {
@@ -787,8 +784,6 @@ class SklearnSerializer(
         attributes = self._extract_estimator_attributes(model)
         attribute_types, attribute_dtypes = self._get_type_maps(attributes)
 
-        print("attribute_types:", attribute_types)
-        print("attribute_dtypes:", attribute_dtypes)
         serializable_attributes = self.convert_to_serializable(attributes)
 
         return {

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -98,7 +98,6 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "LatentDirichletAllocation",  # ValueError: setting an array element with a sequence. The requested array has
     "NeighborhoodComponentsAnalysis",  # This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "RandomTreesEmbedding",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: OneHotEncoder
     "SelectFdr",  # Object of type function is not JSON serializable
     "SelectFpr",  # Object of type function is not JSON serializable
     "SelectFwe",  # Object of type function is not JSON serializable

--- a/openmodels/serializers/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn_serializer.py
@@ -91,18 +91,13 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "HDBSCAN",  # data type "[('left_node', '<i8'), ('right_node', '<i8')...]" not understood
     # Transformers:
     "ColumnTransformer",  # AttributeError: 'dict' object has no attribute 'transform'
-    "DictVectorizer",  # ValueError:
     "FeatureHasher",  # TypeError: 'NoneType' object is not iterable
     "FeatureUnion",  # AttributeError: 'dict' object has no attribute 'transform'
     "GenericUnivariateSelect",  # Object of type function is not JSON serializable
-    "HashingVectorizer",  # openmodels.exceptions.SerializationError: Cannot serialize an unfitted model
-    "KBinsDiscretizer",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: OneHotEncoder
-    "KNeighborsTransformer",  # ValueError:
+    "HashingVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
     "LatentDirichletAllocation",  # ValueError: setting an array element with a sequence. The requested array has
     "NeighborhoodComponentsAnalysis",  # This NeighborhoodComponentsAnalysis estimator requires y to be passed, but the target y is None.
-    "OneHotEncoder",  # ValueError:
     "PatchExtractor",  # ValueError: not enough values to unpack (expected 3, got 2)
-    "RadiusNeighborsTransformer",  # ValueError:
     "RandomTreesEmbedding",  # openmodels.exceptions.UnsupportedEstimatorError: Unsupported estimator class: OneHotEncoder
     "SelectFdr",  # Object of type function is not JSON serializable
     "SelectFpr",  # Object of type function is not JSON serializable
@@ -113,12 +108,8 @@ NOT_SUPPORTED_ESTIMATORS: list[str] = [
     "SparseRandomProjection",  # ValueError: lead to a target dimension of 3353 which is larger than the original space with n_features=5
     "SplineTransformer",  # Object of type BSpline is not JSON serializable
     "TargetEncoder",  # ValueError: Expected array-like (array or non-string sequence), got None
-    "TfidfTransformer",  # ValueError
-    # Others:
-    "CountVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
     "IsolationForest",  # TypeError: only integer scalar arrays can be converted to a scalar index
     "LocalOutlierFactor",  # AttributeError: This 'LocalOutlierFactor' has no attribute 'predict'
-    "TfidfVectorizer",  # AttributeError: 'numpy.ndarray' object has no attribute 'lower'
 ]
 
 
@@ -239,6 +230,7 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
         "_intercept_",
     ],
     "NearestNeighbors": ["_fit_method", "_tree", "_fit_X"],
+    "TfidfVectorizer": ["_tfidf"],
 }
 
 
@@ -769,9 +761,12 @@ class SklearnSerializer(
         >>> serializer = SklearnSerializer()
         >>> serialized_dict = serializer.serialize(model)
         """
+        print("Serializing model of type:", model.__class__.__name__)
         # Extract and build estimator params and its types/dtypes map
         params = model.get_params(deep=False)
         param_types, param_dtypes = self._get_type_maps(params)
+        print("param_types:", param_types)
+        print("param_dtypes:", param_dtypes)
 
         # Build serializable estimator including extra info
         serialized_estimator = {
@@ -792,6 +787,9 @@ class SklearnSerializer(
         # Extract and build fitted attributes and its types/dtypes map
         attributes = self._extract_estimator_attributes(model)
         attribute_types, attribute_dtypes = self._get_type_maps(attributes)
+
+        print("attribute_types:", attribute_types)
+        print("attribute_dtypes:", attribute_dtypes)
         serializable_attributes = self.convert_to_serializable(attributes)
 
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openmodels"
-version = "0.1.0-alpha.12"
+version = "0.1.0-alpha.13"
 description = "Export scikit-learn model files to JSON for sharing or deploying predictive models with peace of mind."
 authors = [
     "Alejandro Gutierrez <agutierrez@sftec.es>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>, Ruben Parrilla <rparrilla@sftec.es>",

--- a/test/test_others.py
+++ b/test/test_others.py
@@ -50,6 +50,17 @@ def test_others(Others, data):
     x, y = data
 
     args = {}
+    # Special handling for text vectorizers
+    if Others.__name__ in ["CountVectorizer", "TfidfVectorizer"]:
+        # Provide a list of strings as input data
+        x = [
+            "this is a test document",
+            "another test document",
+            "text data for vectorizer",
+            "machine learning is fun",
+            "openmodels serialization test"
+        ]
+        y = None  # y is not used for vectorizers
     if Others.__name__ == "FrozenEstimator":
         from sklearn.linear_model import LogisticRegression
         base_estimator = LogisticRegression()


### PR DESCRIPTION
This PR updates the test infrastructure to robustly compare sparse matrix outputs regardless of dtype, resolving previous test failures for estimators that return integer or float sparse matrices. As a result, several estimators that were previously commented out or marked as unsupported now pass all serialization/deserialization tests.

Key changes:

- Added `assert_sparse_matrix_equal` to test helpers, comparing sparse matrices by value (as float64) instead of requiring exact dtype matches.
- Updated test logic to use this function for all sparse matrix outputs.
- The serializer continues to preserve the original dtype for roundtrip fidelity.
- Special handling for text vectorizers:
In `test_others.py`, the test now detects text vectorizers (`CountVectorizer`, `TfidfVectorizer`) and provides a list of strings as input data, since these estimators require string input rather than numeric arrays. This ensures that these estimators are tested correctly and do not fail due to input type errors.

Estimators now supported by this fix:
- `CountVectorizer`
- `TfidfVectorizer`
- `DictVectorizer`
- `KNeighborsTransformer`
- `OneHotEncoder`
- `RadiusNeighborsTransformer`

These estimators can now be included in the test suite and are no longer listed in `NOT_SUPPORTED_ESTIMATORS`.