### PR TITLE
test: add automated sklearn version compatibility workflow

### DIFF
--- a/.github/workflows/sklearn-compat.yml
+++ b/.github/workflows/sklearn-compat.yml
@@ -22,8 +22,6 @@ jobs:
           - sklearn-version: '1.7.2'
           - sklearn-version: '1.8.0'
 
-    continue-on-error: ${{ matrix.experimental == true }}
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sklearn-compat.yml
+++ b/.github/workflows/sklearn-compat.yml
@@ -1,0 +1,50 @@
+name: scikit-learn compatibility
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'openmodels/**'
+      - 'test/**'
+      - '.github/workflows/sklearn-compat.yml'
+  schedule:
+    - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  sklearn-compat:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sklearn-version: '1.6.1'
+          - sklearn-version: '1.7.2'
+          - sklearn-version: '1.8.0'
+
+    continue-on-error: ${{ matrix.experimental == true }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Override scikit-learn version
+        run: poetry run pip install "scikit-learn==${{ matrix.sklearn-version }}" --force-reinstall
+
+      - name: Print environment
+        run: |
+          python --version
+          poetry run python -c "import sklearn; print('sklearn:', sklearn.__version__)"
+
+      - name: Run tests
+        run: poetry run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,5 @@ poetry.lock
 test/temp/*.json
 .coverage
 .coverage.*
-CALUDE.md
+CLAUDE.md
 .tox/

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ poetry.lock
 test/temp/*.json
 .coverage
 .coverage.*
+CALUDE.md
+.tox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,121 @@ All notable changes to the OpenModels project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-alpha.21] - 2026-03-14
+
+### Added
+
+- Automated CI workflow (`.github/workflows/sklearn-compat.yml`) to test against scikit-learn 1.6.1, 1.7.2, and 1.8.0 on every push to `main`, weekly, and on demand
+- README compatibility matrix listing tested scikit-learn versions with a call for users to report incompatibilities
+
+### Fixed
+
+- `AttributeError` when serializing `SimpleImputer` on scikit-learn < 1.8.0: `_fill_dtype` (introduced in 1.8.0) is now skipped gracefully via a `hasattr` guard, preserving compatibility across all supported versions
+
+## [0.1.0-alpha.20] - 2025-10-01
+
+### Added
+
+- High-level `save()` and `load()` methods on `SerializationManager` for convenient file I/O
+- README example for custom estimator support
+
+### Changed
+
+- Minor internal refactoring: removed redundant code and enforced UTF-8 encoding for text mode I/O
+
+## [0.1.0-alpha.19] - 2025-06-01
+
+### Added
+
+- Support for custom and third-party estimators via `custom_estimators` parameter on `SklearnSerializer`
+- README example showing integration with [chemotools](https://github.com/paucablop/chemotools) pipelines
+
+## [0.1.0-alpha.16] - 2025-01-01
+
+### Added
+
+- [Taskfile](https://taskfile.dev/) for standardised developer workflows (`test`, `lint`, `format`, `type-check`, `build`, etc.)
+- Python 3.13 added to CI matrix
+- Code coverage reporting via codecov
+
+### Changed
+
+- Moved `SklearnSerializer` to its own subfolder (`openmodels/serializers/sklearn/`) for better organisation
+- Stopped tracking `poetry.lock` in version control
+
+## [0.1.0-alpha.14] - 2024-11-01
+
+### Added
+
+- Extended scikit-learn estimator support:
+  - `TargetEncoder`, `SplineTransformer` (scipy BSpline), `IsolationForest`
+  - `NeighborhoodComponentsAnalysis`, `LatentDirichletAllocation`
+  - `ColumnTransformer`, `FeatureUnion`
+  - `OutputCodeClassifier`, `OneVsOneClassifier`
+  - `HDBSCAN`, `FeatureAgglomeration`, `BisectingKMeans`
+  - `GenericUnivariateSelect`, `SelectFdr`, `SelectFpr`, `SelectFwe`, `SelectKBest`, `SelectPercentile`
+  - `HashingVectorizer`, `FeatureHasher`, `SparseRandomProjection`, `SkewedChi2Sampler`
+  - `LocalOutlierFactor` (predict-only)
+- Python function serialisation support (used by feature selection estimators)
+
+## [0.1.0-alpha.13] - 2024-10-15
+
+### Fixed
+
+- Dtype-robust sparse matrix comparison in tests
+- `RandomTreesEmbedding` re-enabled after `OneHotEncoder` fix
+
+## [0.1.0-alpha.12] - 2024-10-01
+
+### Added
+
+- Extended scikit-learn estimator support:
+  - `Birch`, `TunedThresholdClassifierCV`
+  - `GradientBoostingClassifier`, `GradientBoostingRegressor`
+  - `HistGradientBoostingClassifier`, `HistGradientBoostingRegressor`
+  - `GaussianProcessClassifier`, `GaussianProcessRegressor` (with kernel serialisation)
+  - `CalibratedClassifierCV`, `LinearDiscriminantAnalysis`
+
+## [0.1.0-alpha.11] - 2024-09-15
+
+### Changed
+
+- Refactored serialization layer to a mixin-based architecture (`NumpySerializerMixin`, `ScipySerializerMixin`) for extensibility and modularity
+- Improved recursive deserialization for nested estimators and special types
+
+## [0.1.0-alpha.10] - 2024-09-01
+
+### Added
+
+- scikit-learn version tracking: the serialized payload now records the sklearn version used, and a `UserWarning` is raised on version mismatch at deserialization time
+- Dynamic TestPyPI badge in README
+
+### Fixed
+
+- CI badge auto-update loop
+
+## [0.1.0-alpha.5] - 2024-08-20
+
+### Added
+
+- Type and dtype tracking for model parameters during serialization
+- Support for nested estimators (e.g. pipelines, meta-estimators)
+- `KDTree` serialization support
+- `IsotonicRegression`, `TweedieRegressor`, `PoissonRegressor`, `GammaRegressor` support
+- NumPy array dtype preservation (fixes `BaggingRegressor` and similar)
+
+### Fixed
+
+- Serialization of numpy arrays of estimators
+- Pipeline serialization
+
+## [0.1.0-alpha.4] - 2024-08-15
+
+### Changed
+
+- Dynamic estimator loading using `sklearn.utils.discovery.all_estimators`
+- Improved attribute handling in `SklearnSerializer`
+
 ## [0.1.0-alpha.1] - 2024-08-06
 
 ### Added
@@ -23,22 +138,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic test suite for supported models
 - Documentation including README, LICENSE, and CONTRIBUTING guidelines
 
-### Changed
-
-- N/A (First release)
-
-### Deprecated
-
-- N/A (First release)
-
-### Removed
-
-- N/A (First release)
-
-### Fixed
-
-- N/A (First release)
-
 ### Security
 
 - Implemented safe alternatives to pickle serialization
@@ -50,5 +149,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for TensorFlow models
 - YAML serialization format
 - Enhanced documentation with more examples and use cases
-- Improved test coverage
 - Support for more scikit-learn models including ensemble methods and neural networks

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 SFTec
+Copyright (c) 2024 Gnpd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If you encounter any incompatibility or a use case where the library does not wo
 
 We welcome contributions to OpenModels! Whether you want to add support for new models, implement new serialization formats, or improve the existing codebase, your help is appreciated.
 
-Please refer to our [Contributing Guidelines](https://github.com/SF-Tec/openmodels/blob/main/CONTRIBUTING.md) for more information on how to get started.
+Please refer to our [Contributing Guidelines](https://github.com/Gnpd/openmodels/blob/main/CONTRIBUTING.md) for more information on how to get started.
 
 ## Running Tests
 
@@ -214,15 +214,15 @@ To run the tests:
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](https://github.com/SF-Tec/openmodels/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/Gnpd/openmodels/blob/main/LICENSE) file for details.
 
 ## Changelog
 
-For a detailed changelog, please see the [CHANGELOG.md](https://github.com/SF-Tec/openmodels/blob/main/CHANGELOG.md) file.
+For a detailed changelog, please see the [CHANGELOG.md](https://github.com/Gnpd/openmodels/blob/main/CHANGELOG.md) file.
 
 ## Support
 
-If you encounter any issues or have questions, please [file an issue](https://github.com/SF-Tec/openmodels/issues/new) on our GitHub repository.
+If you encounter any issues or have questions, please [file an issue](https://github.com/Gnpd/openmodels/issues/new) on our GitHub repository.
 
 We're always looking to improve OpenModels. If you have any suggestions or feature requests, please let us know!
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/openmodels.svg?cacheBust=1)](https://badge.fury.io/py/openmodels)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python Versions](https://img.shields.io/pypi/pyversions/openmodels.svg?cacheBust=1)](https://pypi.org/project/openmodels/)
-[![TestPyPI](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/SF-Tec/openmodels/refs/heads/main/testpypi-badge.json)](https://test.pypi.org/project/openmodels/)
+[![TestPyPI](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Gnpd/openmodels/refs/heads/main/testpypi-badge.json)](https://test.pypi.org/project/openmodels/)
 
 OpenModels is a flexible and extensible library for serializing and deserializing machine learning models. It's designed to support any serialization format through a plugin-based architecture, providing a safe and transparent solution for exporting and sharing predictive models.
 
@@ -168,6 +168,18 @@ print(y_train_pred)
 ```
 
 You can pass any compatible `all_estimators` function, list, or dictionary to `SklearnSerializer(custom_estimators=...)` to extend support for custom or third-party estimators.
+
+## scikit-learn Version Compatibility
+
+OpenModels is automatically tested against the following scikit-learn versions on every push to `main` and weekly via CI:
+
+| scikit-learn | Status |
+|---|---|
+| 1.6.1 | ✅ Tested |
+| 1.7.2 | ✅ Tested |
+| 1.8.0 | ✅ Tested |
+
+If you encounter any incompatibility or a use case where the library does not work correctly with your version of scikit-learn, please [open an issue](https://github.com/Gnpd/openmodels/issues/new) — we would greatly appreciate your feedback!
 
 ## Contributing
 

--- a/openmodels/serializers/sklearn/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn/sklearn_serializer.py
@@ -437,7 +437,8 @@ class SklearnSerializer(
         attribute_keys = [key for key in dir(estimator) if is_valid_attribute(key)]
         attribute_keys += ATTRIBUTE_EXCEPTIONS.get(estimator.__class__.__name__, [])
 
-        attributes = {key: getattr(estimator, key) for key in attribute_keys}
+        # Prevents attribute exceptions introduced in newer scikit-learn versions from breaking older versions of the serializer
+        attributes = {key: getattr(estimator, key) for key in attribute_keys if hasattr(estimator, key)}
 
         return attributes
 

--- a/openmodels/serializers/sklearn/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn/sklearn_serializer.py
@@ -267,7 +267,7 @@ class SklearnSerializer(
     smoothly and that we cover any unique types or patterns used in your library.
 
     To request official support for your package, please open an issue at:
-    https://github.com/SF-Tec/openmodels/issues
+    https://github.com/Gnpd/openmodels/issues
 
     """
 

--- a/openmodels/serializers/sklearn/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn/sklearn_serializer.py
@@ -82,7 +82,7 @@ ALL_ESTIMATORS["_BinaryGaussianProcessClassifierLaplace"] = (
 )
 ALL_ESTIMATORS["_ConstantPredictor"] = _ConstantPredictor
 
-TESTED_VERSIONS = ["1.6.1", "1.7.2"]
+TESTED_VERSIONS = ["1.6.1", "1.7.2", "1.8.0"]
 
 NOT_SUPPORTED_ESTIMATORS: list[str] = [
     # Regressors: all regressors work!! Hurray!
@@ -190,7 +190,7 @@ ATTRIBUTE_EXCEPTIONS: Dict[str, List] = {
     "KNeighborsTransformer": ["_fit_method", "_tree", "_fit_X"],
     "PowerTransformer": ["_scaler"],
     "RadiusNeighborsTransformer": ["_fit_method", "_tree"],
-    "SimpleImputer": ["_fit_dtype"],
+    "SimpleImputer": ["_fit_dtype", "_fill_dtype"],
     "MiniBatchNMF": ["_n_components", "_transform_max_iter", "_beta_loss", "_gamma"],
     "MissingIndicator": ["_n_features", "_precomputed"],
     "MultiLabelBinarizer": ["_cached_dict"],

--- a/openmodels/serializers/sklearn/sklearn_serializer.py
+++ b/openmodels/serializers/sklearn/sklearn_serializer.py
@@ -438,7 +438,11 @@ class SklearnSerializer(
         attribute_keys += ATTRIBUTE_EXCEPTIONS.get(estimator.__class__.__name__, [])
 
         # Prevents attribute exceptions introduced in newer scikit-learn versions from breaking older versions of the serializer
-        attributes = {key: getattr(estimator, key) for key in attribute_keys if hasattr(estimator, key)}
+        attributes = {
+            key: getattr(estimator, key)
+            for key in attribute_keys
+            if hasattr(estimator, key)
+        }
 
         return attributes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openmodels"
-version = "0.1.0-alpha.20"
+version = "0.1.0-alpha.21"
 description = "Export scikit-learn model files to JSON for sharing or deploying predictive models with peace of mind."
 authors = [
     "Alejandro Gutierrez <agutierrez@sftec.es>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>, Ruben Parrilla <rparrilla@sftec.es>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "openmodels"
 version = "0.1.0-alpha.21"
 description = "Export scikit-learn model files to JSON for sharing or deploying predictive models with peace of mind."
 authors = [
-    "Alejandro Gutierrez <agutierrez@sftec.es>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>, Ruben Parrilla <rparrilla@sftec.es>",
+    "Alejandro Gutierrez <a.gutierrez@g-npd.com>, Pau Cabaneros <pau.cabaneros@gmail.com>, Raúl Marín <hi@raulmarin.dev>",
 ]
 license = "MIT"
 readme = "README.md"

--- a/testpypi-badge.json
+++ b/testpypi-badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "TestPyPI",
-  "message": "0.1.0a20",
+  "message": "0.1.0a21",
   "color": "orange"
 }


### PR DESCRIPTION
Add `.github/workflows/sklearn-compat.yml` to test against sklearn **1.6.1**, **1.7.2**, and **1.8.0** on push to main, weekly, and on demand. Update README  with a compatibility matrix and a call for users to report issues.

resolves issue #42 