### PR TITLE
Add support scikit-learn 1.9.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,6 @@
 name: Deploy Docs
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - 'docs/**'
-            - 'openmodels/**'
-            - 'pyproject.toml'
-            - '.github/workflows/docs.yml'
     workflow_dispatch:
 
 permissions:

--- a/openmodels/serializers/sklearn/_custom_estimator.py
+++ b/openmodels/serializers/sklearn/_custom_estimator.py
@@ -19,7 +19,7 @@ def is_valid_estimator(name: str, cls: Any) -> bool:
 
 
 def normalize_estimators(
-    estimators: Union[Callable[..., Any], List[Any], Tuple[Any, ...], Dict[str, Any]]
+    estimators: Union[Callable[..., Any], List[Any], Tuple[Any, ...], Dict[str, Any]],
 ) -> List[Any]:
     """Normalize input into a flat list of estimators or (name, class) items."""
     if not isinstance(estimators, (list, tuple, set)):

--- a/openmodels/test_helpers.py
+++ b/openmodels/test_helpers.py
@@ -47,7 +47,7 @@ T = TypeVar("T", bound=Union[BaseEstimator, ModelType])
 
 
 def ensure_correct_sparse_format(
-    x: Union[np.ndarray, csr_matrix]
+    x: Union[np.ndarray, csr_matrix],
 ) -> Union[np.ndarray, csr_matrix]:
     """
     Ensure the input data is in the correct format for SVM models.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ scikit-learn = "^1.6.0"
 [tool.poetry.group.dev.dependencies]
 poetry-types = "^0.6.2"
 mypy = "^1.10.0"
-pytest = "^8.2.2"
+pytest = "^9.0.3"
 pre-commit = "^3.7.1"
 black = "^26.3.1"
 flake8 = "^7.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.10,<4.0"
 scikit-learn = "^1.6.0"
 
 [tool.poetry.group.dev.dependencies]
-poetry-types = "^0.5.1"
+poetry-types = "^0.6.2"
 mypy = "^1.10.0"
 pytest = "^8.2.2"
 pre-commit = "^3.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ poetry-types = "^0.6.2"
 mypy = "^1.10.0"
 pytest = "^8.2.2"
 pre-commit = "^3.7.1"
-black = "^24.4.2"
+black = "^26.3.1"
 flake8 = "^7.1.1"
 pytest-cov = "^7.0.0"
 


### PR DESCRIPTION
- `.github/workflows/sklearn-compat.yml`: added sklearn-version: '1.9.0' to the matrix.
- `openmodels/serializers/sklearn/sklearn_serializer.py`: sklearn 1.9 added a new fit-time private attribute _effective_probability on SVM estimators, which `predict()` now depends on internally. Added it to `ATTRIBUTE_EXCEPTIONS` for `SVR`, `NuSVR`, `SVC`, and `NuSVC` so it round-trips through serialize/deserialize, without this, `predict()` on a deserialized SVR/NuSVR raised AttributeError.
- `test/test_classification.py` and `test/test_regression.py`: sklearn 1.9 fully removed the deprecated `base_estimator` constructor argument on ClassifierChain/RegressorChain in favor of `estimator` (already the pattern used elsewhere in `test_others.py`). 